### PR TITLE
Update CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![VulcanClimateModeling](https://circleci.com/gh/VulcanClimateModeling/fv3gfs-fortran.svg?style=svg)](https://circleci.com/gh/VulcanClimateModeling/fv3gfs-fortran)
+[![CircleCI](https://circleci.com/gh/ai2cm/fv3gfs-fortran/tree/master.svg?style=svg)](https://circleci.com/gh/ai2cm/fv3gfs-fortran/tree/master)
 
 # Repository Structure
 


### PR DESCRIPTION
This updates the CircleCI badge in the README.  The old URL no longer works because the name of our organization changed.