### PR TITLE
Implement feature to reduce sub-domain sizes near the edges

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -284,6 +284,13 @@ module fv_arrays_mod
                                      !<  3: the lat-lon grid -- to be implemented
                                      !<  4: double periodic boundary condition on Cartesian grid
                                      !<  5: channel flow on Cartesian grid
+
+   real(kind=R_GRID) :: edge_subdomain_shrink_factor = 1.0 !< Factor by which the subdomains with edges & corners
+                                                           !< are reduced in width as compared to an even partitioning
+                                                           !< Factors between (0.0, 1.0] are legal, where 1.0 corresponds
+                                                           !< to the default (no shrinking). Note that subdomains need to
+                                                           !< have a minimal number of gridpoints (ng).
+
 !  -> moved to grid_tools
 
 ! Momentum (or KE) options:

--- a/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_grid_tools.F90
@@ -782,7 +782,7 @@ contains
                 dx(i,j) = great_circle_dist( p2, p1, radius )
              enddo
           enddo
-          if( stretched_grid ) then
+          if( stretched_grid .or. Atm%flagstruct%edge_subdomain_shrink_factor < 1.0 ) then
              do j = jstart, jend
                 do i = istart, iend+1
                    p1(1) = grid(i,j,  1)
@@ -793,6 +793,8 @@ contains
                 enddo
              enddo
           else
+             ! Note: get_symmetry makes some assumptions about subdomain size which will cause
+             !       it to fail if edge_subdomain_shrink_factor < 1.0
              call get_symmetry(dx(is:ie,js:je+1), dy(is:ie+1,js:je), 0, 1, Atm%layout(1), Atm%layout(2), &
                   Atm%domain, Atm%tile, Atm%gridstruct%npx_g, Atm%bd)
           endif

--- a/FV3/atmos_cubed_sphere/tools/fv_mp_mod.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_mp_mod.F90
@@ -1,4 +1,4 @@
-!***********************************************************************
+ !***********************************************************************
 !*                   GNU Lesser General Public License                 
 !*
 !* This file is part of the FV3 dynamical core.
@@ -80,7 +80,7 @@
       use mpp_domains_mod, only : GLOBAL_DATA_DOMAIN, BITWISE_EXACT_SUM, BGRID_NE, FOLD_NORTH_EDGE, CGRID_NE
       use mpp_domains_mod, only : MPP_DOMAIN_TIME, CYCLIC_GLOBAL_DOMAIN, NUPDATE,EUPDATE, XUPDATE, YUPDATE, SCALAR_PAIR
       use mpp_domains_mod, only : domain1D, domain2D, DomainCommunicator2D, mpp_get_ntile_count
-      use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain
+      use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain, mpp_compute_extent
       use mpp_domains_mod, only : mpp_global_field, mpp_global_sum, mpp_global_max, mpp_global_min
       use mpp_domains_mod, only : mpp_domains_init, mpp_domains_exit, mpp_broadcast_domain
       use mpp_domains_mod, only : mpp_check_field, mpp_define_layout 
@@ -347,13 +347,14 @@ contains
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !>@brief The subroutine 'domain_decomp' sets up the domain decomposition.
-      subroutine domain_decomp(npx,npy,nregions,grid_type,nested,Atm,layout,io_layout)
+      subroutine domain_decomp(npx,npy,nregions,grid_type,nested,Atm,layout,io_layout,edge_subdomain_shrink_factor)
 
          integer, intent(IN)  :: npx,npy,grid_type
          integer, intent(INOUT) :: nregions
          logical, intent(IN):: nested
          type(fv_atmos_type), intent(INOUT), target :: Atm
          integer, intent(INOUT) :: layout(2), io_layout(2)
+         real, intent(IN), optional :: edge_subdomain_shrink_factor
 
          integer, allocatable :: pe_start(:), pe_end(:)
 
@@ -362,13 +363,21 @@ contains
          logical :: is_symmetry 
          logical :: debug=.false.
          integer, allocatable :: tile_id(:)
+         real :: shrink_factor
 
-         integer i
+         integer :: i, shrink_size
+         integer :: ibegin(layout(1)), iend(layout(1)), jbegin(layout(2)), jend(layout(2))
          integer :: npes_x, npes_y 
+         integer :: xextent(layout(1),nregions), yextent(layout(2),nregions)
 
          integer, pointer :: pelist(:), grid_number, num_contact, npes_per_tile
          logical, pointer :: square_domain
          type(domain2D), pointer :: domain, domain_for_coupler
+
+         shrink_factor = 1.0
+         if (present(edge_subdomain_shrink_factor)) then
+            shrink_factor = max(0.0, min(1.0, edge_subdomain_shrink_factor))
+         end if
 
          nx = npx-1
          ny = npy-1
@@ -635,14 +644,43 @@ contains
                   tile_id(n) = n
                enddo
             endif
+            xextent(:, :) = 0.0
+            yextent(:, :) = 0.0
+            if (shrink_factor < 1.0) then
+                ! We reduce the width of the subdomains at the edges so that they are edge_subdomain_shrink_factor
+                ! smaller than "inner" subdomains with no edges/corners. We compute the size of the edge subdomains
+                ! in shrink_size and then evenly distribute the remaining gridpoints using mpp_compute_extent().
+                if (layout(1) > 2) then
+                   shrink_size = nint( real(nx) / (2.0 + real(layout(1)-2)/shrink_factor) )
+                   shrink_size = max(ng, shrink_size)
+                   call mpp_compute_extent(shrink_size + 1, nx - shrink_size, layout(1)-2, ibegin(2:layout(1)-1), iend(2:layout(1)-1))
+                   xextent(1, :) = shrink_size
+                   xextent(layout(1), :) = shrink_size
+                   do i = 1, nregions
+                      xextent(2:layout(1)-1, i) = iend(2:layout(1)-1) - ibegin(2:layout(1)-1) + 1
+                   end do
+                end if
+                if (layout(2) > 2) then
+                  shrink_size = nint( real(ny) / (2.0 + real(layout(2)-2)/shrink_factor) )
+                  shrink_size = max(ng, shrink_size)
+                  call mpp_compute_extent(shrink_size + 1, ny - shrink_size, layout(2)-2, jbegin(2:layout(2)-1), jend(2:layout(2)-1))
+                  yextent(1, :) = shrink_size
+                  yextent(layout(1), :) = shrink_size
+                  do i = 1, nregions
+                     yextent(2:layout(2)-1, i) = jend(2:layout(2)-1) - jbegin(2:layout(2)-1) + 1
+                  end do
+               end if
+            end if
             call mpp_define_mosaic(global_indices, layout2D, domain, nregions, num_contact, tile1, tile2, &
                  istart1, iend1, jstart1, jend1, istart2, iend2, jstart2, jend2,      &
                  pe_start=pe_start, pe_end=pe_end, symmetry=is_symmetry,              &
-                 shalo = ng, nhalo = ng, whalo = ng, ehalo = ng, tile_id=tile_id, name = type)
+                 shalo = ng, nhalo = ng, whalo = ng, ehalo = ng, tile_id=tile_id, name = type, &
+                 xextent=xextent, yextent=yextent)
             call mpp_define_mosaic(global_indices, layout2D, domain_for_coupler, nregions, num_contact, tile1, tile2, &
                  istart1, iend1, jstart1, jend1, istart2, iend2, jstart2, jend2,                  &
                  pe_start=pe_start, pe_end=pe_end, symmetry=is_symmetry,                          &
-                 shalo = 1, nhalo = 1, whalo = 1, ehalo = 1, tile_id=tile_id, name = type)
+                 shalo = 1, nhalo = 1, whalo = 1, ehalo = 1, tile_id=tile_id, name = type, &
+                 xextent=xextent, yextent=yextent)
             deallocate(tile_id)
             call mpp_define_io_domain(domain, io_layout)
             call mpp_define_io_domain(domain_for_coupler, io_layout)

--- a/FV3/atmos_cubed_sphere/tools/fv_mp_mod.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_mp_mod.F90
@@ -665,7 +665,7 @@ contains
                   shrink_size = max(ng, shrink_size)
                   call mpp_compute_extent(shrink_size + 1, ny - shrink_size, layout(2)-2, jbegin(2:layout(2)-1), jend(2:layout(2)-1))
                   yextent(1, :) = shrink_size
-                  yextent(layout(1), :) = shrink_size
+                  yextent(layout(2), :) = shrink_size
                   do i = 1, nregions
                      yextent(2:layout(2)-1, i) = jend(2:layout(2)-1) - jbegin(2:layout(2)-1) + 1
                   end do


### PR DESCRIPTION
This PR implements a new feature to be able to reduce the sub-domains of the MPI ranks which are at the edges of the cubed-sphere grid. This can be useful to hide the overhead of the edges & corner calculations since reducing the subdomains will result in overall faster execution for those ranks as compared to "inner" ranks with larger sub-domains.

The feature is implemented via a new namelist option `edge_subdomain_shrink_factor` which can take values from 0 to 1, where 1 is the default value and corresponds to no shrinking of the edge sub-domains. For a value of x < 1, the code will aim to have a achieve a ratio of # gridpoints of edge rank to inner rank corresponding to that value. A minimal width is imposed via a limiter in order to ensure constraints of FV3GFS are satisfied.

The implementation is mostly localized in `fv_mp_mod.f90`, except for the logic dealing with the new namelist option. There is some logic that computes the width of the sub-domains at the edges and then the same standard partitioning scheme is re-used for the inner ranks with `mpp_compute_extent()` which tries to achieve symmetry along the edges.