### PR TITLE
Fix daint paths and introduce some checks

### DIFF
--- a/.jenkins/actions/benchmark_bare_metal.sh
+++ b/.jenkins/actions/benchmark_bare_metal.sh
@@ -18,9 +18,6 @@ set -o pipefail
 #   FV3_EXECUTABLE     - Name of executable to use (these executables are stored under /project/s1053/install/fv3gfs-fortran.
 #   TIMESTEPS          - Number of timesteps to run benchmark for.
 
-FV3_EXE_DIR=${PROJECT}/../install/fv3gfs-fortran/
-PERFORMANCE_DIR=${PROJECT}/../performance/fv3core_performance/fortran
-
 ##################################################
 # functions
 ##################################################
@@ -93,6 +90,25 @@ set -e
 
 # load scheduler tools
 . ${envloc}/env/schedulerTools.sh
+
+# make sure environment is sane
+FV3_EXE_DIR=${installdir}/fv3gfs-fortran/
+PERFORMANCE_DIR=${installdir}/../performance/fv3core_performance/fortran
+if [ ! -d "${FV3_EXE_DIR}" ] ; then
+    exitError 400 ${LINENO} "The directory FV3_EXE_DIR=${FV3_EXE_DIR} does not exist."
+fi
+if [ ! -d "${PERFORMANCE_DIR}" ] ; then
+    exitError 410 ${LINENO} "The directory PERFORMANCE_DIR=${PERFORMANCE_DIR} does not exist."
+fi
+if [ -z "${CONFIGURATION_LIST}" ] ; then
+    exitError 420 ${LINENO} "The variable CONFIGURATION_LIST=${CONFIGURATION_LIST} is not set."
+fi
+if [ -z "${FV3_EXECUTABLE}" ] ; then
+    exitError 430 ${LINENO} "The variable FV3_EXECUTABLE=${FV3_EXECUTABLE} is not set."
+fi
+if [ -z "${TIMESTEPS}" ] ; then
+    exitError 440 ${LINENO} "The variable TIMESTEPS=${TIMESTEPS} is not set."
+fi
 
 # run the benchmarks
 # note: this relies on the fact that daint_gnu and daint_intel are the first

--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -17,9 +17,6 @@ set -o pipefail
 #   EXECUTABLE_SUFFIX  - Suffix to add to executable name when copied to /project
 #   EXECUTABLE_NAMES   - Names of executable to use for tests (space separated)
 
-INSTALL_DIR=${PROJECT}/../install
-FV3GFSEXE_DIR=${INSTALL_DIR}/fv3gfs-fortran/
-
 ##################################################
 # functions
 ##################################################
@@ -98,6 +95,18 @@ set -e
 
 # load scheduler tools
 . ${envloc}/env/schedulerTools.sh
+
+# make sure environment is sane
+FV3GFS_EXE_DIR=${installdir}/fv3gfs-fortran/
+if [ ! -d "${FV3_EXE_DIR}" ] ; then
+    exitError 400 ${LINENO} "The directory FV3_EXE_DIR=${FV3_EXE_DIR} does not exist."
+fi
+if [ ! -d "${CONFIGURATION_LIST}" ] ; then
+    exitError 410 ${LINENO} "The variable CONFIGURATION_LIST=${CONFIGURATION_LIST} is not set."
+fi
+if [ -z "${EXECUTABLE_NAMES}" ] ; then
+    exitError 420 ${LINENO} "The variable EXECUTABLE_NAMES=${EXECUTABLE_NAMES} is not set."
+fi
 
 # compile the model
 # note: this relies on the fact that daint_gnu and daint_intel are the first


### PR DESCRIPTION
This should resolve the current issue the benchmark daint bare metal plan is having and fetches the /project/s1053/install directory from the single source of truth (buildenv).