### PR TITLE
Add emulator diagnostics

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -3799,6 +3799,8 @@ module GFS_diagnostics
     ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
   enddo
 
+  call populate_emulator_diagnostics(ExtDiag, IntDiag, nblks, idx)
+
 !--------------------------aerosols
 #ifdef CCPP
     if (Model%ntwa>0) then
@@ -4257,5 +4259,12 @@ module GFS_diagnostics
 #endif
 
 !-------------------------------------------------------------------------      
+  subroutine populate_emulator_diagnostics(ExtDiag, IntDiag, nblks, idx)
+    type(GFS_externaldiag_type),  intent(inout) :: ExtDiag(:)
+    type(GFS_diag_type),          intent(in)    :: IntDiag(:)
+    integer, intent(in) :: nblks
+    integer, intent(inout) :: idx
+
+  end subroutine
 
 end module GFS_diagnostics

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -4270,13 +4270,14 @@ module GFS_diagnostics
     integer, intent(inout) :: idx
     ! locals
     integer nb
+    character(len=128), parameter :: module_name = "zhao_carr_microphysics"
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_' // trim(label)
     ExtDiag(idx)%desc = 'temperature tendency due to Zhao Carr ' // trim(label)
     ExtDiag(idx)%unit = 'K/s'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%mod_name = module_name
     ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
     ExtDiag(idx)%diag_manager_controlled = .true.
     allocate (ExtDiag(idx)%data(nblks))
@@ -4285,10 +4286,10 @@ module GFS_diagnostics
     end do
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_' // trim(label)
     ExtDiag(idx)%desc = 'specific humidity tendency due to Zhao Carr ' // trim(label)
     ExtDiag(idx)%unit = 'kg/kg/s'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%mod_name = module_name
     ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
     ExtDiag(idx)%diag_manager_controlled = .true.
     allocate (ExtDiag(idx)%data(nblks))
@@ -4298,10 +4299,10 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 3
-    ExtDiag(idx)%name = 'tendency_of_cloud_water_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%name = 'tendency_of_cloud_water_due_to_' // trim(label)
     ExtDiag(idx)%desc = 'cloud water due to Zhao Carr ' // trim(label)
     ExtDiag(idx)%unit = 'kg/kg/s'
-    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%mod_name = module_name
     ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
     ExtDiag(idx)%diag_manager_controlled = .true.
     allocate (ExtDiag(idx)%data(nblks))

--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -14,7 +14,7 @@ module GFS_diagnostics
                                 GFS_coupling_type, GFS_grid_type,     &
                                 GFS_tbd_type,      GFS_cldprop_type,  &
                                 GFS_radtend_type,  GFS_diag_type,  &
-                                GFS_init_type
+                                GFS_init_type, zhao_carr_tendencies
   implicit none
   private
 
@@ -3799,7 +3799,10 @@ module GFS_diagnostics
     ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
   enddo
 
-  call populate_emulator_diagnostics(ExtDiag, IntDiag, nblks, idx)
+  call populate_emulator_diagnostics(&
+    ExtDiag, IntDiag(:)%zhao_carr_emulator, 'emulator', nblks, idx)
+  call populate_emulator_diagnostics(&
+    ExtDiag, IntDiag(:)%zhao_carr_physics, 'physics', nblks, idx)
 
 !--------------------------aerosols
 #ifdef CCPP
@@ -4259,11 +4262,52 @@ module GFS_diagnostics
 #endif
 
 !-------------------------------------------------------------------------      
-  subroutine populate_emulator_diagnostics(ExtDiag, IntDiag, nblks, idx)
+  subroutine populate_emulator_diagnostics(ExtDiag, tendencies, label, nblks, idx)
     type(GFS_externaldiag_type),  intent(inout) :: ExtDiag(:)
-    type(GFS_diag_type),          intent(in)    :: IntDiag(:)
+    type(zhao_carr_tendencies),          intent(in)    :: tendencies(:)
+    character(len=*), intent(in) :: label
     integer, intent(in) :: nblks
     integer, intent(inout) :: idx
+    ! locals
+    integer nb
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'tendency_of_air_temperature_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%desc = 'temperature tendency due to Zhao Carr ' // trim(label)
+    ExtDiag(idx)%unit = 'K/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+    ExtDiag(idx)%diag_manager_controlled = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => tendencies(nb)%temperature
+    end do
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'tendency_of_specific_humidity_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%desc = 'specific humidity tendency due to Zhao Carr ' // trim(label)
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+    ExtDiag(idx)%diag_manager_controlled = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => tendencies(nb)%humidity
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'tendency_of_cloud_water_due_to_zhao_carr_' // trim(label)
+    ExtDiag(idx)%desc = 'cloud water due to Zhao Carr ' // trim(label)
+    ExtDiag(idx)%unit = 'kg/kg/s'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%coarse_graining_method = 'mass_weighted'
+    ExtDiag(idx)%diag_manager_controlled = .true.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => tendencies(nb)%cloud_water
+    enddo
 
   end subroutine
 

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4587,8 +4587,8 @@ module module_physics_driver
             call get_state("total_precipitation", rain1)
 
             if (Model%ldiag3d) then
-              Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs, 1) - dqdt(:,:,1)) * frain
-              Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs,ntcw) - dqdt(:,:,ntcw)) * frain
+              Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) * frain
+              Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs) - dqdt(:,:,ntcw)) * frain
               Diag%zhao_carr_emulator%temperature = (t_post_precpd(1:im,1:levs) - dtdt) * frain
             end if
 

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -600,7 +600,8 @@ module module_physics_driver
       !--- intermediate for callpyfort set_state
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs) ::  &
           qv_cpf, qc_cpf, qvp_cpf, tp_cpf, qvp1_cpf, tp1_cpf,           &
-          qv_post_gscond, qc_post_gscond, qv_post_precpd, qc_post_precpd
+          qv_post_gscond, qc_post_gscond, qv_post_precpd, qc_post_precpd,&
+          t_post_precpd
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1))  ::            &
           psp_cpf, psp1_cpf
@@ -4550,8 +4551,15 @@ module module_physics_driver
                         Stateout%gq0(1,1,1), Stateout%gq0(1,1,ntcw),           &
                         Stateout%gt0, rain1, Diag%sr, rainp, rhc, psautco_l,   &
                         prautco_l, Model%evpco, Model%wminco, lprnt, ipr)
-            
+
+            if (Model%ldiag3d) then
+              Diag%zhao_carr_physics%humidity = (Stateout%gq0(1:im,1:levs, 1) - dqdt(:,:,1)) * frain
+              Diag%zhao_carr_physics%cloud_water = (Stateout%gq0(1:im,1:levs,ntcw) - dqdt(:,:,ntcw)) * frain
+              Diag%zhao_carr_physics%temperature = (Stateout%gt0(1:im,1:levs) - dtdt) * frain
+            end if
+
 #ifdef ENABLE_CALLPYFORT
+
             do k=1,levs
               do i=1,im
                 qv_post_precpd(i,k) = Stateout%gq0(i,k,1)
@@ -4567,26 +4575,34 @@ module module_physics_driver
             call set_state("ratio_of_snowfall_to_rainfall", Diag%sr)
             call set_state("tendency_of_rain_water_mixing_ratio_due_to_microphysics", rainp)
 
-            if (Model%emulate_zc_microphysics) then
-              ! apply microphysics emulator
-              call call_function("emulation", "microphysics")
-            endif
+            call call_function("emulation", "microphysics")
             
             if (Model%save_zc_microphysics) then
               call call_function("emulation", "store")
             endif
 
-            call get_state("air_temperature_output", Stateout%gt0)
+            call get_state("air_temperature_output", t_post_precpd)
             call get_state("specific_humidity_output", qv_post_precpd)
             call get_state("cloud_water_mixing_ratio_output", qc_post_precpd)
             call get_state("total_precipitation", rain1)
 
-            do k=1,levs
-              do i=1,im
-                Stateout%gq0(i,k,1) = qv_post_precpd(i,k)
-                Stateout%gq0(i,k,ntcw) = qc_post_precpd(i,k)
+            if (Model%ldiag3d) then
+              Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs, 1) - dqdt(:,:,1)) * frain
+              Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs,ntcw) - dqdt(:,:,ntcw)) * frain
+              Diag%zhao_carr_emulator%temperature = (t_post_precpd(1:im,1:levs) - dtdt) * frain
+            end if
+
+            ! apply emulator
+            if (Model%emulate_zc_microphysics) then
+              do k=1,levs
+                do i=1,im
+                  Stateout%gq0(i,k,1) = qv_post_precpd(i,k)
+                  Stateout%gq0(i,k,ntcw) = qc_post_precpd(i,k)
+                  Stateout%gt0(i,k) = t_post_precpd(i,k)
+                enddo
               enddo
-            enddo
+            endif
+
 #endif
             
           endif

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4553,9 +4553,9 @@ module module_physics_driver
                         prautco_l, Model%evpco, Model%wminco, lprnt, ipr)
 
             if (Model%ldiag3d) then
-              Diag%zhao_carr_physics%humidity = (Stateout%gq0(1:im,1:levs, 1) - dqdt(:,:,1)) * frain
-              Diag%zhao_carr_physics%cloud_water = (Stateout%gq0(1:im,1:levs,ntcw) - dqdt(:,:,ntcw)) * frain
-              Diag%zhao_carr_physics%temperature = (Stateout%gt0(1:im,1:levs) - dtdt) * frain
+              Diag%zhao_carr_physics%humidity = (Stateout%gq0(1:im,1:levs, 1) - dqdt(:,:,1)) / dtp
+              Diag%zhao_carr_physics%cloud_water = (Stateout%gq0(1:im,1:levs,ntcw) - dqdt(:,:,ntcw)) / dtp
+              Diag%zhao_carr_physics%temperature = (Stateout%gt0(1:im,1:levs) - dtdt) / dtp
             end if
 
 #ifdef ENABLE_CALLPYFORT
@@ -4587,9 +4587,9 @@ module module_physics_driver
             call get_state("total_precipitation", rain1)
 
             if (Model%ldiag3d) then
-              Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) * frain
-              Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs) - dqdt(:,:,ntcw)) * frain
-              Diag%zhao_carr_emulator%temperature = (t_post_precpd(1:im,1:levs) - dtdt) * frain
+              Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) / dtp
+              Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs) - dqdt(:,:,ntcw)) / dtp
+              Diag%zhao_carr_emulator%temperature = (t_post_precpd(1:im,1:levs) - dtdt) / dtp
             end if
 
             ! apply emulator

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1315,6 +1315,16 @@ module GFS_typedefs
       procedure :: create  => radtend_create   !<   allocate array data
   end type GFS_radtend_type
 
+
+  type zhao_carr_tendencies
+    real (kind=kind_phys), pointer :: temperature(:, :) => null()
+    real (kind=kind_phys), pointer :: humidity(:, :) => null()
+    real (kind=kind_phys), pointer :: cloud_water(:, :) => null()
+
+    contains
+      procedure :: create => zhao_carr_tendencies_create
+      procedure :: zero => zhao_carr_tendencies_zero
+  end type
 !----------------------------------------------------------------
 ! GFS_diag_type
 !  internal diagnostic type used as arguments to gbphys and grrad 
@@ -1499,6 +1509,8 @@ module GFS_typedefs
 
     !--- MP quantities for 3D diagnositics 
     real (kind=kind_phys), pointer :: refl_10cm(:,:) => null()  !< instantaneous refl_10cm 
+
+    type(zhao_carr_tendencies) :: zhao_carr_emulator, zhao_carr_physics
 !
 !---vay-2018 UGWP-diagnostics daily mean
 !
@@ -1955,6 +1967,7 @@ module GFS_typedefs
          GFS_coupling_type
   public GFS_control_type,  GFS_grid_type,     GFS_tbd_type, &
          GFS_cldprop_type,  GFS_radtend_type,  GFS_diag_type
+  public zhao_carr_tendencies
 #ifdef CCPP
   public GFS_interstitial_type
 #endif
@@ -1962,6 +1975,20 @@ module GFS_typedefs
 !*******************************************************************************************
   CONTAINS
 
+  subroutine zhao_carr_tendencies_create(tendency, im, levels)
+    class(zhao_carr_tendencies), intent(inout) :: tendency
+    integer, intent(in) :: im, levels
+    allocate(tendency%temperature(im, levels))
+    allocate(tendency%humidity(im, levels))
+    allocate(tendency%cloud_water(im, levels))
+  end subroutine
+
+  subroutine zhao_carr_tendencies_zero(tendency)
+    class(zhao_carr_tendencies), intent(inout) :: tendency
+    tendency%temperature = zero
+    tendency%cloud_water = zero
+    tendency%humidity = zero
+  end subroutine
 !------------------------
 ! GFS_statein_type%create
 !------------------------
@@ -5196,6 +5223,8 @@ module GFS_typedefs
       allocate (Diag%dq3dt  (IM,Model%levs,9))
       allocate (Diag%q_dt   (IM,Model%levs,5))
       allocate (Diag%q_dt_int (IM,5))
+      call Diag%zhao_carr_emulator%create(im, Model%levs)
+      call Diag%zhao_carr_physics%create(im, Model%levs)
 !      allocate (Diag%dq3dt  (IM,Model%levs,oz_coeff+5))
 !--- needed to allocate GoCart coupling fields
 !      allocate (Diag%upd_mf (IM,Model%levs))
@@ -5507,6 +5536,8 @@ module GFS_typedefs
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
       Diag%dq3dt    = zero
+      call Diag%zhao_carr_emulator%zero()
+      call Diag%zhao_carr_physics%zero()
 !     Diag%upd_mf   = zero
 !     Diag%dwn_mf   = zero
 !     Diag%det_mf   = zero

--- a/tests/emulation/README.md
+++ b/tests/emulation/README.md
@@ -45,17 +45,17 @@ diag_table:
       field_configs:
         - field_name: tendency_of_air_temperature_due_to_emulator
           module_name: zhao_carr_microphysics
-          output_name: tendency_of_air_temperature_due_to_emulator
-        - field_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
+          output_name: tendency_of_air_temperature_due_to_zhao_carr_emulator
+        - field_name: tendency_of_cloud_water_due_to_emulator
           module_name: zhao_carr_microphysics
-          output_name: tendency_of_cloud_water_due_to_emulator
-        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
+          output_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
+        - field_name: tendency_of_specific_humidity_due_to_emulator
           module_name: zhao_carr_microphysics
-          output_name: tendency_of_specific_humidity_due_to_emulator
-        - field_name: tendency_of_air_temperature_due_to_zhao_carr_physics
+          output_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
+        - field_name: tendency_of_air_temperature_due_to_physics
           module_name: zhao_carr_microphysics
-          output_name: tendency_of_air_temperature_due_to_physics
-        - field_name: tendency_of_cloud_water_due_to_zhao_carr_physics
+          output_name: tendency_of_air_temperature_due_to_zhao_carr_physics
+        - field_name: tendency_of_cloud_water_due_to_physics
           module_name: zhao_carr_microphysics
           output_name: tendency_of_cloud_water_due_to_zhao_carr_physics
         - field_name: tendency_of_specific_humidity_due_to_physics

--- a/tests/emulation/README.md
+++ b/tests/emulation/README.md
@@ -27,6 +27,42 @@ Available input state fields for emulation
 - ratio_of_snowfall_to_rainfall
 - tendency_of_rain_water_mixing_ratio_due_to_microphysics
 
+
+Fortran Diagnostics
+----------------------------------------
+
+Several diagnostics related to the emulator have been added the fortran diagnostics manager.
+Here is a an example `diag_table` configuration with these:
+
+```
+diag_table:
+  name: emulation_diags
+  base_time: 2000-01-01T00:00:00
+  file_configs:
+    - name: physics
+      frequency: 1
+      frequency_units: "hours"
+      field_configs:
+        - field_name: tendency_of_air_temperature_due_to_emulator
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_air_temperature_due_to_emulator
+        - field_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_cloud_water_due_to_emulator
+        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_specific_humidity_due_to_emulator
+        - field_name: tendency_of_air_temperature_due_to_zhao_carr_physics
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_air_temperature_due_to_physics
+        - field_name: tendency_of_cloud_water_due_to_zhao_carr_physics
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_cloud_water_due_to_zhao_carr_physics
+        - field_name: tendency_of_specific_humidity_due_to_physics
+          module_name: zhao_carr_microphysics
+          output_name: tendency_of_specific_humidity_due_to_zhao_carr_physics
+```
+
 Notes
 -----
 

--- a/tests/pytest/config/emulation.yml
+++ b/tests/pytest/config/emulation.yml
@@ -1,30 +1,5 @@
 data_table: default
-diag_table:
-  name: emulation_diags
-  base_time: 2000-01-01T00:00:00
-  file_configs:
-    - name: physics
-      frequency: 1
-      frequency_units: "hours"
-      field_configs:
-        - field_name: tendency_of_air_temperature_due_to_zhao_carr_emulator
-          module_name: gfs_phys
-          output_name: tendency_of_air_temperature_due_to_zhao_carr_emulator
-        - field_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
-          module_name: gfs_phys
-          output_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
-        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
-          module_name: gfs_phys
-          output_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
-        - field_name: tendency_of_air_temperature_due_to_zhao_carr_physics
-          module_name: gfs_phys
-          output_name: tendency_of_air_temperature_due_to_zhao_carr_physics
-        - field_name: tendency_of_cloud_water_due_to_zhao_carr_physics
-          module_name: gfs_phys
-          output_name: tendency_of_cloud_water_due_to_zhao_carr_physics
-        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_physics
-          module_name: gfs_phys
-          output_name: tendency_of_specific_humidity_due_to_zhao_carr_physics
+diag_table: default
 experiment_name: microphysics_emulation
 forcing: "gs://vcm-fv3config/data/base_forcing/v1.1/"
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
@@ -259,7 +234,7 @@ namelist:
     isubc_lw: 2
     isubc_sw: 2
     ivegsrc: 1
-    ldiag3d: true
+    ldiag3d: false
     lwhtr: true
     ncld: 1
     nst_anl: true

--- a/tests/pytest/config/emulation.yml
+++ b/tests/pytest/config/emulation.yml
@@ -1,5 +1,30 @@
 data_table: default
-diag_table: default
+diag_table:
+  name: emulation_diags
+  base_time: 2000-01-01T00:00:00
+  file_configs:
+    - name: physics
+      frequency: 1
+      frequency_units: "hours"
+      field_configs:
+        - field_name: tendency_of_air_temperature_due_to_zhao_carr_emulator
+          module_name: gfs_phys
+          output_name: tendency_of_air_temperature_due_to_zhao_carr_emulator
+        - field_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
+          module_name: gfs_phys
+          output_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
+        - field_name: tendency_of_air_specific_humidity_due_to_zhao_carr_emulator
+          module_name: gfs_phys
+          output_name: tendency_of_air_specific_humidity_due_to_zhao_carr_emulator
+        - field_name: tendency_of_air_temperature_due_to_zhao_carr_physics
+          module_name: gfs_phys
+          output_name: tendency_of_air_temperature_due_to_zhao_carr_physics
+        - field_name: tendency_of_cloud_water_due_to_zhao_carr_physics
+          module_name: gfs_phys
+          output_name: tendency_of_cloud_water_due_to_zhao_carr_physics
+        - field_name: tendency_of_air_specific_humidity_due_to_zhao_carr_physics
+          module_name: gfs_phys
+          output_name: tendency_of_air_specific_humidity_due_to_zhao_carr_physics
 experiment_name: microphysics_emulation
 forcing: "gs://vcm-fv3config/data/base_forcing/v1.1/"
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/tests/pytest/config/emulation.yml
+++ b/tests/pytest/config/emulation.yml
@@ -259,7 +259,7 @@ namelist:
     isubc_lw: 2
     isubc_sw: 2
     ivegsrc: 1
-    ldiag3d: false
+    ldiag3d: true
     lwhtr: true
     ncld: 1
     nst_anl: true

--- a/tests/pytest/config/emulation.yml
+++ b/tests/pytest/config/emulation.yml
@@ -13,18 +13,18 @@ diag_table:
         - field_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
           module_name: gfs_phys
           output_name: tendency_of_cloud_water_due_to_zhao_carr_emulator
-        - field_name: tendency_of_air_specific_humidity_due_to_zhao_carr_emulator
+        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
           module_name: gfs_phys
-          output_name: tendency_of_air_specific_humidity_due_to_zhao_carr_emulator
+          output_name: tendency_of_specific_humidity_due_to_zhao_carr_emulator
         - field_name: tendency_of_air_temperature_due_to_zhao_carr_physics
           module_name: gfs_phys
           output_name: tendency_of_air_temperature_due_to_zhao_carr_physics
         - field_name: tendency_of_cloud_water_due_to_zhao_carr_physics
           module_name: gfs_phys
           output_name: tendency_of_cloud_water_due_to_zhao_carr_physics
-        - field_name: tendency_of_air_specific_humidity_due_to_zhao_carr_physics
+        - field_name: tendency_of_specific_humidity_due_to_zhao_carr_physics
           module_name: gfs_phys
-          output_name: tendency_of_air_specific_humidity_due_to_zhao_carr_physics
+          output_name: tendency_of_specific_humidity_due_to_zhao_carr_physics
 experiment_name: microphysics_emulation
 forcing: "gs://vcm-fv3config/data/base_forcing/v1.1/"
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0


### PR DESCRIPTION
Add 6 new diagnostics quantities. This is more robust to do in fortran because it already handles multiple blocks and the conversion from `(i,level)` to `(x,y,level)`.

- `tendency_of_air_temperature_due_to_zhao_carr_emulator`
- `tendency_of_cloud_water_due_to_zhao_carr_emulator`
- `tendency_of_air_specific_humidity_due_to_zhao_carr_emulator`
- `tendency_of_air_temperature_due_to_zhao_carr_physics`
- `tendency_of_cloud_water_due_to_zhao_carr_physics`
- `tendency_of_air_specific_humidity_due_to_zhao_carr_physics`