### PR TITLE
emulation: save state after gscond

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4575,9 +4575,9 @@ module module_physics_driver
               enddo
             enddo
 
-            call set_state("air_temperature_output", Stateout%gt0)
-            call set_state("specific_humidity_output", qv_post_precpd)
-            call set_state("cloud_water_mixing_ratio_output", qc_post_precpd)
+            call set_state("air_temperature_after_precpd", Stateout%gt0)
+            call set_state("specific_humidity_after_precpd", qv_post_precpd)
+            call set_state("cloud_water_mixing_ratio_after_precpd", qc_post_precpd)
             call set_state("total_precipitation", rain1)
             call set_state("ratio_of_snowfall_to_rainfall", Diag%sr)
             call set_state("tendency_of_rain_water_mixing_ratio_due_to_microphysics", rainp)
@@ -4588,11 +4588,11 @@ module module_physics_driver
               call call_function("emulation", "store")
             endif
 
-            call get_state("air_temperature_output", t_post_precpd)
-            call get_state("specific_humidity_output", qv_post_precpd)
-            call get_state("cloud_water_mixing_ratio_output", qc_post_precpd)
-            call get_state("air_temperature_after_gscond_output", tp_cpf)
-            call get_state("specific_humdity_after_gscond_output", qvp_cpf)
+            call get_state("air_temperature_after_precpd", t_post_precpd)
+            call get_state("specific_humidity_after_precpd", qv_post_precpd)
+            call get_state("cloud_water_mixing_ratio_after_precpd", qc_post_precpd)
+            call get_state("air_temperature_after_gscond", tp_cpf)
+            call get_state("specific_humdity_after_gscond", qvp_cpf)
 
             if (Model%ldiag3d) then
               Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) / dtp

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -610,8 +610,7 @@ module module_physics_driver
         t_post_precpd, &
         tp_cpf
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1))  ::            &
-          psp_cpf, psp1_cpf
+      real(kind=kind_phys), dimension(size(Grid%xlon,1))  :: psp_cpf
 #endif
 
 !--- ALLOCATABLE ELEMENTS
@@ -4523,7 +4522,6 @@ module module_physics_driver
 
               do i=1,im
                 psp_cpf(i) = Tbd%phy_f2d(i,1)
-                psp1_cpf(i) = Tbd%phy_f2d(i,2)
               enddo
 
   !           For creating training data & emulation

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4591,6 +4591,7 @@ module module_physics_driver
             call get_state("air_temperature_after_precpd", t_post_precpd)
             call get_state("specific_humidity_after_precpd", qv_post_precpd)
             call get_state("cloud_water_mixing_ratio_after_precpd", qc_post_precpd)
+            call get_state("total_precipitation", rain1)
             call get_state("air_temperature_after_gscond", tp_cpf)
             call get_state("specific_humdity_after_gscond", qvp_cpf)
 

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4550,7 +4550,7 @@ module module_physics_driver
 
 #ifdef ENABLE_CALLPYFORT
             call set_state("specific_humidity_after_gscond", Stateout%gq0(1:im, 1:levs, 1))
-            call set_state("surface_air_pressure_after_gscond", Stateout%gt0(1:im, 1:levs))
+            call set_state("air_temperature_after_gscond", Stateout%gt0(1:im, 1:levs))
 #endif
 
             call precpd (im, ix, levs, dtp, del, Statein%prsl,                 &
@@ -4578,7 +4578,6 @@ module module_physics_driver
             call set_state("air_temperature_output", Stateout%gt0)
             call set_state("specific_humidity_output", qv_post_precpd)
             call set_state("cloud_water_mixing_ratio_output", qc_post_precpd)
-
             call set_state("total_precipitation", rain1)
             call set_state("ratio_of_snowfall_to_rainfall", Diag%sr)
             call set_state("tendency_of_rain_water_mixing_ratio_due_to_microphysics", rainp)
@@ -4592,7 +4591,8 @@ module module_physics_driver
             call get_state("air_temperature_output", t_post_precpd)
             call get_state("specific_humidity_output", qv_post_precpd)
             call get_state("cloud_water_mixing_ratio_output", qc_post_precpd)
-            call get_state("total_precipitation", rain1)
+            call get_state("air_temperature_after_gscond_output", tp_cpf)
+            call get_state("specific_humdity_after_gscond_output", qvp_cpf)
 
             if (Model%ldiag3d) then
               Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) / dtp
@@ -4608,6 +4608,8 @@ module module_physics_driver
                   Stateout%gq0(i,k,1) = qv_post_precpd(i,k)
                   Stateout%gq0(i,k,ntcw) = qc_post_precpd(i,k)
                   Stateout%gt0(i,k) = t_post_precpd(i,k)
+                  Tbd%phy_f3d(i,k,1) = tp_cpf(i,k)
+                  Tbd%phy_f3d(i,k,2) = qvp_cpf(i,k)
                 enddo
               enddo
             endif

--- a/nix/fv3/default.nix
+++ b/nix/fv3/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
   inherit fms;
   buildInputs = [
       call_py_fort
+      call_py_fort.pypkgs.black
       call_py_fort.pypkgs.fv3config
       call_py_fort.pypkgs.numpy
       call_py_fort.pypkgs.pytest

--- a/tests/emulation/README.md
+++ b/tests/emulation/README.md
@@ -5,28 +5,21 @@ A basic implementation of `emulation` is provided to test the call_py_fort calls
 
 The interaction points with python are located in `GFS_physics_driver.f90` as the `set_state`, `get_state`, and `call_function` commands.   Using `make build_emulation` from the parent directory will provide a compiled image with call_py_fort functionality enabled.  Two namelist flags can be used to turn off storage (`gfs_physics_nml.save_zc_microphysics`) and emulation (`gfs_physics_nml.emulate_zc_microphysics`) while call_py_fort is enabled.
 
-The emulation function `microphysics` should overwrite the fields `air_temperature_output`, `specific_humidity_output`, `cloud_water_mixing_ratio_output`, `total_precipitation`, to control the microphysical updates during runtime.  Otherwise, the default parameterization will be in control.
+The emulation function `microphysics` should overwrite the fields:
+- `air_temperature_output`
+- `specific_humidity_output`
+- `cloud_water_mixing_ratio_output`
+- `total_precipitation`
+- `air_temperature_after_gscond_output`
+- `specific_humidity_after_gscond_output`
+
+to control the microphysical updates during runtime.  Otherwise
+the default parameterization will be in control.
 
 Available input state fields for emulation
 ------------------------------------------
-- model_time
-- latitude
-- longitude
-- pressure_thickness_of_atmospheric_layer
-- air_pressure
-- surface_air_pressure
-- air_temperature_input
-- specific_humidity_input
-- cloud_water_mixing_ratio_input
-- air_temperature_two_time_steps_back
-- specific_humidity_two_time_steps_back
-- surface_air_pressure_two_time_steps_back
-- air_temperature_at_previous_time_step
-- specific_humidity_at_previous_time_step
-- surface_air_pressure_at_previous_time_step
-- ratio_of_snowfall_to_rainfall
-- tendency_of_rain_water_mixing_ratio_due_to_microphysics
 
+See [this test](emulation/emulate.py) for a list of fields.
 
 Fortran Diagnostics
 ----------------------------------------

--- a/tests/emulation/README.md
+++ b/tests/emulation/README.md
@@ -6,12 +6,12 @@ A basic implementation of `emulation` is provided to test the call_py_fort calls
 The interaction points with python are located in `GFS_physics_driver.f90` as the `set_state`, `get_state`, and `call_function` commands.   Using `make build_emulation` from the parent directory will provide a compiled image with call_py_fort functionality enabled.  Two namelist flags can be used to turn off storage (`gfs_physics_nml.save_zc_microphysics`) and emulation (`gfs_physics_nml.emulate_zc_microphysics`) while call_py_fort is enabled.
 
 The emulation function `microphysics` should overwrite the fields:
-- `air_temperature_output`
-- `specific_humidity_output`
-- `cloud_water_mixing_ratio_output`
+- `air_temperature_after_precpd`
+- `specific_humidity_after_precpd`
+- `cloud_water_mixing_ratio_after_precpd`
 - `total_precipitation`
-- `air_temperature_after_gscond_output`
-- `specific_humidity_after_gscond_output`
+- `air_temperature_after_gscond`
+- `specific_humidity_after_gscond`
 
 to control the microphysical updates during runtime.  Otherwise
 the default parameterization will be in control.

--- a/tests/emulation/emulation/emulate.py
+++ b/tests/emulation/emulation/emulate.py
@@ -3,13 +3,41 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-def microphysics(state):
 
+def assert_expected_variables_present(state):
+
+    expected_fields = {
+        "air_pressure",
+        "air_temperature_after_last_gscond",
+        "air_temperature_input",
+        "air_temperature_output",
+        "cloud_water_mixing_ratio_input",
+        "cloud_water_mixing_ratio_output",
+        "latitude",
+        "longitude",
+        "model_time",
+        "pressure_thickness_of_atmospheric_layer",
+        "ratio_of_snowfall_to_rainfall",
+        "specific_humidity_after_gscond",
+        "specific_humidity_after_last_gscond",
+        "specific_humidity_input",
+        "specific_humidity_output",
+        "surface_air_pressure_after_gscond",
+        "surface_air_pressure_after_last_gscond",
+        "surface_air_pressure",
+        "tendency_of_rain_water_mixing_ratio_due_to_microphysics",
+        "total_precipitation",
+    }
+
+    assert expected_fields == set(state)
+
+
+def microphysics(state):
+    assert_expected_variables_present(state)
     try:
         with open(f"microphysics_success.txt", "w") as f:
             f.write("SUCCESS")
     except Exception as e:
         logger.error(e)
         raise e
-
     logger.info("Successful call to microphysics in emulate.py")

--- a/tests/emulation/emulation/emulate.py
+++ b/tests/emulation/emulation/emulate.py
@@ -8,6 +8,7 @@ def assert_expected_variables_present(state):
 
     expected_fields = {
         "air_pressure",
+        "air_temperature_after_gscond",
         "air_temperature_after_last_gscond",
         "air_temperature_input",
         "air_temperature_output",
@@ -22,7 +23,6 @@ def assert_expected_variables_present(state):
         "specific_humidity_after_last_gscond",
         "specific_humidity_input",
         "specific_humidity_output",
-        "surface_air_pressure_after_gscond",
         "surface_air_pressure_after_last_gscond",
         "surface_air_pressure",
         "tendency_of_rain_water_mixing_ratio_due_to_microphysics",

--- a/tests/emulation/emulation/emulate.py
+++ b/tests/emulation/emulation/emulate.py
@@ -10,10 +10,10 @@ def assert_expected_variables_present(state):
         "air_pressure",
         "air_temperature_after_gscond",
         "air_temperature_after_last_gscond",
+        "air_temperature_after_precpd",
         "air_temperature_input",
-        "air_temperature_output",
+        "cloud_water_mixing_ratio_after_precpd",
         "cloud_water_mixing_ratio_input",
-        "cloud_water_mixing_ratio_output",
         "latitude",
         "longitude",
         "model_time",
@@ -21,15 +21,15 @@ def assert_expected_variables_present(state):
         "ratio_of_snowfall_to_rainfall",
         "specific_humidity_after_gscond",
         "specific_humidity_after_last_gscond",
+        "specific_humidity_after_precpd",
         "specific_humidity_input",
-        "specific_humidity_output",
         "surface_air_pressure_after_last_gscond",
         "surface_air_pressure",
         "tendency_of_rain_water_mixing_ratio_due_to_microphysics",
         "total_precipitation",
     }
 
-    assert expected_fields == set(state)
+    assert expected_fields == set(state), set(state)
 
 
 def microphysics(state):


### PR DESCRIPTION
The temperature and humidity states after gscond are used to compute a relative
humidity tendency in the following timestep. Also, we always run the model with
the same physics (dtp) and dynamics (dtf) timestep, so the tp1 and cp1 variables
are identical to cp. dtp is actually set equal to dtf in the model startup.
See this
[notebook](https://github.com/ai2cm/explore/blob/master/noahb/emulation/microphysics/2021-11-03-verify%20tbd%20data.ipynb)
for proof.

* Remove the redundnant call py fort state setting for tp1_cpf, etc
* Rename the output of `tp` etc to be more accurate
* Save the temperature and humidity state after `gscond`
* Install black in nix environment to make development easier