### PR TITLE
CALLPYFORT is off for serialization

### DIFF
--- a/.jenkins/actions/serialize_data.sh
+++ b/.jenkins/actions/serialize_data.sh
@@ -98,6 +98,7 @@ export DOCKER_BUILDKIT=1
 export BUILD_ARGS="-q"
 export BUILD_FROM_INTERMEDIATE=y
 export BUILDKIT_PROGRESS=plain
+export CALLPYFORT=
 make pull_deps
 
 # do the work


### PR DESCRIPTION
Set CALLPYFORT to empty in the jenkins action so that it's not on for serialization. 