### PR TITLE
Add option to derive the override for the net surface shortwave radiative flux

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -745,7 +745,7 @@ module module_physics_driver
       if (Model%override_surface_radiative_fluxes) then
         adjsfcdlw_for_lsm => Statein%adjsfcdlw_override
         adjsfcdsw_for_lsm => Statein%adjsfcdsw_override
-        if (Model%derive_net_shortwave_radiative_flux) then
+        if (Model%derive_net_surface_shortwave_radiative_flux) then
           where (adjsfcdsw .gt. 0.0)
             Statein%adjsfcnsw_override = (adjsfcnsw / adjsfcdsw) * Statein%adjsfcdsw_override
           elsewhere

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -745,6 +745,13 @@ module module_physics_driver
       if (Model%override_surface_radiative_fluxes) then
         adjsfcdlw_for_lsm => Statein%adjsfcdlw_override
         adjsfcdsw_for_lsm => Statein%adjsfcdsw_override
+        if (Model%derive_net_shortwave_radiative_flux) then
+          where (adjsfcdsw .gt. 0.0)
+            Statein%adjsfcnsw_override = (adjsfcnsw / adjsfcdsw) * Statein%adjsfcdsw_override
+          elsewhere
+            Statein%adjsfcnsw_override = 0.0
+          endwhere
+        endif
         adjsfcnsw_for_lsm => Statein%adjsfcnsw_override
       else
         adjsfcdlw_for_lsm => adjsfcdlw

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1084,6 +1084,7 @@ module GFS_typedefs
     logical :: iau_filter_increments
     real(kind=kind_phys) :: sst_perturbation  ! Sea surface temperature perturbation to climatology or nudging SST (default 0.0 K)
     logical :: override_surface_radiative_fluxes  ! Whether to use Statein to override the surface radiative fluxes
+    logical :: derive_net_shortwave_radiative_flux  ! Whether to compute the net shortwave radiative flux using override downward shortwave flux and the RRTMG effective albedo 
     logical :: use_climatological_sst  ! Whether to allow the Python wrapper to override the sea surface temperature
     logical :: emulate_zc_microphysics ! Use an emulator in place of ZC microphysics
     logical :: save_zc_microphysics ! Save ZC microphysics state
@@ -3162,6 +3163,7 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: sst_perturbation = 0.0  ! Sea surface temperature perturbation [K]
     logical :: override_surface_radiative_fluxes = .false.
+    logical :: derive_net_shortwave_radiative_flux = .false.
     logical :: use_climatological_sst = .true.
     logical :: emulate_zc_microphysics = .false.
     logical :: save_zc_microphysics = .false.
@@ -3256,8 +3258,10 @@ module GFS_typedefs
                           !--- aerosol scavenging factors ('name:value' string array)
                                fscav_aero, &
                                sst_perturbation,                                            & 
-                               override_surface_radiative_fluxes, use_climatological_sst,   &
-                               emulate_zc_microphysics, save_zc_microphysics
+                               override_surface_radiative_fluxes, &
+                               derive_net_shortwave_radiative_flux, &
+                               use_climatological_sst, emulate_zc_microphysics, &
+                               save_zc_microphysics
 
 !--- other parameters 
     integer :: nctp    =  0                !< number of cloud types in CS scheme
@@ -3726,6 +3730,7 @@ module GFS_typedefs
 
     Model%sst_perturbation = sst_perturbation
     Model%override_surface_radiative_fluxes = override_surface_radiative_fluxes
+    Model%derive_net_shortwave_radiative_flux = derive_net_shortwave_radiative_flux
     Model%use_climatological_sst = use_climatological_sst
 
     !--- emulation parameters
@@ -4544,6 +4549,7 @@ module GFS_typedefs
       print *, ' isot              : ', Model%isot
       print *, ' sst_perturbation  : ', Model%sst_perturbation
       print *, ' override_surface_radiative_fluxes: ', Model%override_surface_radiative_fluxes
+      print *, ' derive_net_shortwave_radiative_flux: ', Model%derive_net_shortwave_radiative_flux
       print *, ' use_climatological_sst: ', Model%use_climatological_sst
       if (Model%lsm == Model%lsm_noahmp) then
       print *, ' Noah MP LSM is used, the options are'

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1084,7 +1084,7 @@ module GFS_typedefs
     logical :: iau_filter_increments
     real(kind=kind_phys) :: sst_perturbation  ! Sea surface temperature perturbation to climatology or nudging SST (default 0.0 K)
     logical :: override_surface_radiative_fluxes  ! Whether to use Statein to override the surface radiative fluxes
-    logical :: derive_net_shortwave_radiative_flux  ! Whether to compute the net shortwave radiative flux using override downward shortwave flux and the RRTMG effective albedo 
+    logical :: derive_net_surface_shortwave_radiative_flux  ! Whether to compute the net shortwave radiative flux using override downward shortwave flux and the RRTMG effective albedo 
     logical :: use_climatological_sst  ! Whether to allow the Python wrapper to override the sea surface temperature
     logical :: emulate_zc_microphysics ! Use an emulator in place of ZC microphysics
     logical :: save_zc_microphysics ! Save ZC microphysics state
@@ -3163,7 +3163,7 @@ module GFS_typedefs
 
     real(kind=kind_phys) :: sst_perturbation = 0.0  ! Sea surface temperature perturbation [K]
     logical :: override_surface_radiative_fluxes = .false.
-    logical :: derive_net_shortwave_radiative_flux = .false.
+    logical :: derive_net_surface_shortwave_radiative_flux = .false.
     logical :: use_climatological_sst = .true.
     logical :: emulate_zc_microphysics = .false.
     logical :: save_zc_microphysics = .false.
@@ -3259,7 +3259,7 @@ module GFS_typedefs
                                fscav_aero, &
                                sst_perturbation,                                            & 
                                override_surface_radiative_fluxes, &
-                               derive_net_shortwave_radiative_flux, &
+                               derive_net_surface_shortwave_radiative_flux, &
                                use_climatological_sst, emulate_zc_microphysics, &
                                save_zc_microphysics
 
@@ -3730,7 +3730,7 @@ module GFS_typedefs
 
     Model%sst_perturbation = sst_perturbation
     Model%override_surface_radiative_fluxes = override_surface_radiative_fluxes
-    Model%derive_net_shortwave_radiative_flux = derive_net_shortwave_radiative_flux
+    Model%derive_net_surface_shortwave_radiative_flux = derive_net_surface_shortwave_radiative_flux
     Model%use_climatological_sst = use_climatological_sst
 
     !--- emulation parameters
@@ -4549,7 +4549,7 @@ module GFS_typedefs
       print *, ' isot              : ', Model%isot
       print *, ' sst_perturbation  : ', Model%sst_perturbation
       print *, ' override_surface_radiative_fluxes: ', Model%override_surface_radiative_fluxes
-      print *, ' derive_net_shortwave_radiative_flux: ', Model%derive_net_shortwave_radiative_flux
+      print *, ' derive_net_surface_shortwave_radiative_flux: ', Model%derive_net_surface_shortwave_radiative_flux
       print *, ' use_climatological_sst: ', Model%use_climatological_sst
       if (Model%lsm == Model%lsm_noahmp) then
       print *, ' Noah MP LSM is used, the options are'


### PR DESCRIPTION
Predicting or computing the net surface shortwave radiative flux based on the downward surface shortwave radiative flux outside the physics driver is difficult, because the effective albedo changes throughout the day.  In the middle of the day, sunlight is typically more direct and more readily absorbed ([notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2021-12-16-albedo/2021-12-16-albedo-issue.ipynb)).  

This PR adds an option to compute the override for the net surface shortwave radiative flux within the physics driver based on the ratio of the net to downward shortwave radiative flux at the surface predicted by RRTMG (this ratio is one minus the albedo).  When the RRTMG-predicted downward shortwave radiative flux at the surface is zero, we assume that the override for the net shortwave radiative flux at the surface will also be zero to avoid divide by zero issues.

I'm marking this as a draft for now as this still needs testing and discussion.