### PR TITLE
implement code coverage reports for native builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ depend
 fv3.exe
 *.tmp.f90
 **/*.egg-info
+*.gcno
+*.gcda

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,13 @@ test: ## run tests (set COMPILED_TAG_NAME to override default)
 build_native: ## build FV3 locally (assuming all tools and dependencies are available in the environment)
 	$(MAKE) -j 8 -C FV3 GCOV=Y
 
+
+test_native: DIR=coverage_$(shell date -Is)
 test_native: ## run native tests (all tools and build dependencies are assumed to be available in the environment)
 	find FV3 -type f -name '*.gcda' -delete
 	pytest --native tests/pytest
-	mkdir -p test_run_$(shell date -Is) && \
-		cd coverage_$(shell date -Is)  && \
+	mkdir -p $(DIR) && \
+		cd $(DIR)  && \
 		gcovr -d -r ../FV3 --html --html-details -o index.html
 
 clean: ## cleanup source tree and test output

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,16 @@ enter_serialize: ## run and enter serialization container for development
 test: ## run tests (set COMPILED_TAG_NAME to override default)
 	pytest tests/pytest --capture=no --verbose --refdir $(shell pwd)/tests/pytest/reference/circleci --image_version $(COMPILED_TAG_NAME)
 
+build_native: ## build FV3 locally (assuming all tools and dependencies are available in the environment)
+	$(MAKE) -j 8 -C FV3 GCOV=Y
+
+test_native: ## run native tests (all tools and build dependencies are assumed to be available in the environment)
+	find FV3 -type f -name '*.gcda' -delete
+	pytest --native tests/pytest
+	mkdir -p test_run_$(shell date -Is) && \
+		cd coverage_$(shell date -Is)  && \
+		gcovr -d -r ../FV3 --html --html-details -o index.html
+
 clean: ## cleanup source tree and test output
 	(cd FV3 && make clean)
 	$(RM) -f inputdata

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ the FV3 makefiles:
 
     cp -f nix/fv3/configure.fv3 FV3/conf/
 
-And build the model
+And build the model (with coverage outputs)
 
-    make -C FV3
+    make build_native
 
 At this point you can run [the native tests](#native-tests).
 # Testing the model
@@ -213,13 +213,19 @@ tests and how to update the reference checksums.
 
 ## Native tests
 
-The `--native` flag only runs tests intended to be run in a native environment
-(e.g. nix, bare metal, or inside a docker container). A native environment is
-capable of running the file `FV3/fv3.exe`.
+Some of the tests can be run in a native environment (e.g. nix, bare metal,
+or inside a docker container). A native environment is capable of running the
+file `FV3/fv3.exe`.
 
-Then, to run some simple tests execute
+After building the model inside of the `FV3` subdirectory, you can run these
+tests like this:
 
+    make test_native
+    # or manually
     pytest --native tests/pytest
+
+When using the makefile target, code coverages reports will be saved to the
+folder `coverage_<timestamp>`.
 
 ## Image tests
 

--- a/nix/fv3/configure.fv3
+++ b/nix/fv3/configure.fv3
@@ -133,6 +133,12 @@ FFLAGS += -I$(CALLPYFORT)/include -DENABLE_CALLPYFORT
 LDFLAGS += -L$(CALLPYFORT)/lib -lcallpy 
 endif
 
+ifneq ($(GCOV),)
+CFLAGS += --coverage
+FFLAGS += --coverage
+LDFLAGS += --coverage
+endif
+
 # static linking of esmf works on darwin
 #LIBS += -lFMS -lnetcdff -lnetcdf -llapack -lblas ${ESMF_DIR}/lib/libesmf.a -lstdc++ #-lc -lrt
 LIBS += -lFMS -lnetcdff -lnetcdf -llapack -lblas -lesmf #-lc -lrt

--- a/nix/fv3/default.nix
+++ b/nix/fv3/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation {
       mpich
       perl
       gfortran
+      # needed for gcov utility
+      gfortran.cc
       getopt
       gcovr
   ];

--- a/nix/fv3/default.nix
+++ b/nix/fv3/default.nix
@@ -13,6 +13,7 @@
   , perl
   , gfortran
   , getopt
+  , gcovr
 } :
 let 
   src = builtins.fetchGit {
@@ -42,6 +43,7 @@ stdenv.mkDerivation {
       perl
       gfortran
       getopt
+      gcovr
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
./coverage.sh only works with docker. Its logic is tightly interwoven with environment management with docker/pip. I implemented some makefile targets which assume all the relevant tools and dependencies are installed and therefore should work from within nix, docker container, or on bare metal.