### PR TITLE
Add interval-average surface temperature diagnostic

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -2923,6 +2923,19 @@ module GFS_diagnostics
 
     idx = idx + 1
     ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'tsfc_ave'
+    ExtDiag(idx)%desc = 'interval averaged surface temperature'
+    ExtDiag(idx)%unit = 'K'
+    ExtDiag(idx)%mod_name = 'gfs_sfc'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+    ExtDiag(idx)%time_avg = .TRUE.
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%tsfc(:)
+    enddo
+
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
     ExtDiag(idx)%name = 'tg3'
     ExtDiag(idx)%desc = 'deep soil temperature'
     ExtDiag(idx)%unit = 'K'

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -5548,6 +5548,9 @@ module module_physics_driver
             final_dynamics_delp, im, levs, nwat, dtp)
       endif
 
+      ! Accumulate surface temperature in diagnostic bucket
+      Diag%tsfc = Diag%tsfc + dtf * Sfcprop%tsfc
+
 !     if (kdt > 2 ) stop
       return
 !...................................

--- a/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1401,6 +1401,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: toticeb(:)     => null()   !< accumulated ice precipitation in bucket (kg/m2)
     real (kind=kind_phys), pointer :: totsnwb(:)     => null()   !< accumulated snow precipitation in bucket (kg/m2)
     real (kind=kind_phys), pointer :: totgrpb(:)     => null()   !< accumulated graupel precipitation in bucket (kg/m2)
+    real (kind=kind_phys), pointer :: tsfc(:)        => null()   !< accumulated surface temperature in bucket (K)
 
 #ifdef CCPP
     !--- MYNN variables                                              
@@ -5130,6 +5131,7 @@ module GFS_typedefs
     allocate (Diag%dqsfc   (IM))
     allocate (Diag%totprcp (IM))
     allocate (Diag%totprcpb(IM))
+    allocate (Diag%tsfc    (IM))
     allocate (Diag%gflux   (IM))
     allocate (Diag%dlwsfc  (IM))
     allocate (Diag%ulwsfc  (IM))
@@ -5526,6 +5528,7 @@ module GFS_typedefs
     Diag%shum_wts   = zero
     Diag%zmtnblck   = zero
     Diag%totprcpb   = zero
+    Diag%tsfc       = zero
     Diag%cnvprcpb   = zero
     Diag%toticeb    = zero
     Diag%totsnwb    = zero


### PR DESCRIPTION
The existing surface temperature diagnostic is strictly instantaneous.  It would be nice to have a version that could be interval averaged.  This addresses that.

Marking as a draft for now, because it still needs to be tested.