### PR TITLE
Add restart reproducibility regression test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       MPIR_CVAR_OFI_SKIP_IPV6: "1"
       FSSPEC_GS_REQUESTER_PAYS: True
+      GOOGLE_CLOUD_PROJECT: vcm-ml
     steps:
       - run: |
           curl -L -O https://nixos.org/nix/install
@@ -43,6 +44,7 @@ jobs:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       FSSPEC_GS_REQUESTER_PAYS: True
+      GOOGLE_CLOUD_PROJECT: vcm-ml
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
       - gcp-cli/install:
         version: 323.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       MPIR_CVAR_OFI_SKIP_IPV6: "1"
+      FSSPEC_GS_REQUESTER_PAYS: True
     steps:
       - run: |
           curl -L -O https://nixos.org/nix/install
@@ -41,6 +42,7 @@ jobs:
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: True
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,13 @@ jobs:
           name: "Install Python test dependencies"
           command: |
             pyenv versions
-            [ -d /opt/circleci/.pyenv/versions/3.8.2 ] || pyenv install 3.8.2
-            pyenv global 3.8.2
+            [ -d /opt/circleci/.pyenv/versions/3.7.0 ] || pyenv install 3.7.0
+            pyenv global 3.7.0
             pip install -r requirements.txt
       - save_cache:
           paths:
             - $FV3CONFIG_CACHE_DIR
-            - /opt/circleci/.pyenv/versions/3.8.2
+            - /opt/circleci/.pyenv/versions/3.7.0
           key: v1.4-{{ checksum "requirements.txt"}}
       # tests
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       MPIR_CVAR_OFI_SKIP_IPV6: "1"
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
       - run: |
           curl -L -O https://nixos.org/nix/install
@@ -41,6 +42,7 @@ jobs:
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,13 @@ jobs:
           name: "Install Python test dependencies"
           command: |
             pyenv versions
-            [ -d /opt/circleci/.pyenv/versions/3.6.2 ] || pyenv install 3.6.2
-            pyenv global 3.6.2
+            [ -d /opt/circleci/.pyenv/versions/3.8.2 ] || pyenv install 3.8.2
+            pyenv global 3.8.2
             pip install -r requirements.txt
       - save_cache:
           paths:
             - $FV3CONFIG_CACHE_DIR
-            - /opt/circleci/.pyenv/versions/3.6.2
+            - /opt/circleci/.pyenv/versions/3.8.2
           key: v1.4-{{ checksum "requirements.txt"}}
       # tests
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ jobs:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       MPIR_CVAR_OFI_SKIP_IPV6: "1"
-      FSSPEC_GS_REQUESTER_PAYS: True
-      GOOGLE_CLOUD_PROJECT: vcm-ml
     steps:
       - run: |
           curl -L -O https://nixos.org/nix/install
@@ -43,8 +41,6 @@ jobs:
     environment:
       FV3CONFIG_CACHE_DIR: /tmp/.fv3config
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
-      FSSPEC_GS_REQUESTER_PAYS: True
-      GOOGLE_CLOUD_PROJECT: vcm-ml
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout

--- a/nix/fv3/default.nix
+++ b/nix/fv3/default.nix
@@ -19,6 +19,17 @@ let
   src = builtins.fetchGit {
     url = ../..;
   };
+  fetchPypi = call_py_fort.pypkgs.fetchPypi;
+  fv3config = let version ="0.9.0";
+  in
+  call_py_fort.pypkgs.fv3config.overridePythonAttrs (attrs :{
+    version = version;
+    src = fetchPypi {
+      version = version;
+      pname = attrs.pname;
+      sha256 = "sha256-iqJdIXQChmiM3hDVcJpV8gc+SoAOSaPGJ6OWuSdzQ0Y=";
+    };
+  });
 in
 stdenv.mkDerivation {
   name = "fv3";
@@ -26,12 +37,12 @@ stdenv.mkDerivation {
   buildInputs = [
       call_py_fort
       call_py_fort.pypkgs.black
-      call_py_fort.pypkgs.fv3config
       call_py_fort.pypkgs.numpy
       call_py_fort.pypkgs.pytest
       call_py_fort.pypkgs.pytest-regtest
       call_py_fort.pypkgs.pyyaml
       call_py_fort.pypkgs.xarray
+      fv3config
       fms
       esmf
       nceplibs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ google-cloud-storage==1.23.0
 pytest-regtest
 numpy
 xarray
-fv3config==0.8.0
+fv3config==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==5.2.2
-gcsfs==0.7.2
-fsspec==0.8.0
+gcsfs==2022.3.0
+fsspec==2022.3.0
 f90nml==1.1.0
 google-cloud-storage==1.23.0
 pytest-regtest

--- a/tests/pytest/config/restart.yml
+++ b/tests/pytest/config/restart.yml
@@ -62,7 +62,7 @@ namelist:
     - 8
     - 1
     - 0
-    - 0
+    - 30
     - 0
     days: 0
     dt_atmos: 900
@@ -74,6 +74,7 @@ namelist:
     ncores_per_node: 32
     seconds: 0
     use_hyper_thread: true
+    force_date_from_namelist: true
   diag_manager_nml:
     prepend_date: false
   external_ic_nml:

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -123,7 +123,6 @@ def test_regression_native(run_native, config_filename: str, tmpdir, system_regt
     _checksum_rundir(str(rundir), file=system_regtest)
 
 
-# @pytest.mark.xfail(reason="https://github.com/ai2cm/fv3config/issues/147")
 @pytest.mark.parametrize(
     "config_filename", ["default.yml", "emulation.yml", "restart.yml"]
 )

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -1,3 +1,5 @@
+import copy
+import datetime
 import glob
 import os
 from os.path import join
@@ -7,6 +9,7 @@ import fv3config
 import numpy as np
 import xarray
 import subprocess
+import typing
 import hashlib
 
 import re
@@ -120,6 +123,40 @@ def test_regression_native(run_native, config_filename: str, tmpdir, system_regt
     _checksum_rundir(str(rundir), file=system_regtest)
 
 
+@pytest.mark.xfail(reason="https://github.com/ai2cm/fv3config/issues/147")
+@pytest.mark.parametrize("config_filename", ["default.yml", "emulation.yml"])
+def test_restart_reproducibility(run_native, config_filename, tmpdir):
+    config_template = get_config(config_filename)
+    config_template["diag_table"] = "no_output"
+    config_template["namelist"]["gfs_physics_nml"]["fhswr"] = 900
+    config_template["namelist"]["gfs_physics_nml"]["fhlwr"] = 900
+
+    segment_1_config = copy.deepcopy(config_template)
+    segment_2_config = copy.deepcopy(config_template)
+    continuous_config = copy.deepcopy(config_template)
+
+    duration = datetime.timedelta(minutes=30)
+    segment_1_config = fv3config.set_run_duration(segment_1_config, duration // 2)
+    segment_2_config = fv3config.set_run_duration(segment_2_config, duration // 2)
+    continuous_config = fv3config.set_run_duration(continuous_config, duration)
+
+    segment_1_rundir = str(tmpdir.join("segment-1"))
+    segment_2_rundir = str(tmpdir.join("segment-2"))
+    continuous_rundir = str(tmpdir.join("continuous"))
+
+    run_native(segment_1_config, segment_1_rundir)
+    run_native(continuous_config, continuous_rundir)
+
+    segment_1_restarts = os.path.join(segment_1_rundir, "RESTART")
+    segment_2_config = fv3config.enable_restart(segment_2_config, segment_1_restarts)
+    run_native(segment_2_config, segment_2_rundir)
+
+    continuous_checksums = _checksum_restart_files(continuous_rundir)
+    segmented_checksums = _checksum_restart_files(segment_2_rundir)
+
+    assert segmented_checksums == continuous_checksums
+
+
 @pytest.fixture(scope="session")
 def emulation_run(run_native, tmpdir_factory):
     config = get_config("emulation.yml")
@@ -193,6 +230,11 @@ def checksum_file(path: str) -> str:
                 break
             sum.update(buf)
     return sum.hexdigest()
+
+
+def _checksum_restart_files(rundir: str) -> typing.Dict[str, str]:
+    restart_files = sorted(glob.glob(os.path.join(rundir, "RESTART", "*.nc")))
+    return {os.path.basename(file): checksum_file(file) for file in restart_files}
 
 
 def _checksum_rundir(rundir: str, file):

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -131,25 +131,23 @@ def test_restart_reproducibility(run_native, config_filename, tmpdir):
     config_template["namelist"]["gfs_physics_nml"]["fhswr"] = 900
     config_template["namelist"]["gfs_physics_nml"]["fhlwr"] = 900
 
-    segment_1_config = copy.deepcopy(config_template)
-    segment_2_config = copy.deepcopy(config_template)
+    segmented_config = copy.deepcopy(config_template)
     continuous_config = copy.deepcopy(config_template)
 
     duration = datetime.timedelta(minutes=30)
-    segment_1_config = fv3config.set_run_duration(segment_1_config, duration // 2)
-    segment_2_config = fv3config.set_run_duration(segment_2_config, duration // 2)
+    segmented_config = fv3config.set_run_duration(segmented_config, duration // 2)
     continuous_config = fv3config.set_run_duration(continuous_config, duration)
 
     segment_1_rundir = str(tmpdir.join("segment-1"))
     segment_2_rundir = str(tmpdir.join("segment-2"))
     continuous_rundir = str(tmpdir.join("continuous"))
 
-    run_native(segment_1_config, segment_1_rundir)
+    run_native(segmented_config, segment_1_rundir)
     run_native(continuous_config, continuous_rundir)
 
     segment_1_restarts = os.path.join(segment_1_rundir, "RESTART")
-    segment_2_config = fv3config.enable_restart(segment_2_config, segment_1_restarts)
-    run_native(segment_2_config, segment_2_rundir)
+    segmented_config = fv3config.enable_restart(segmented_config, segment_1_restarts)
+    run_native(segmented_config, segment_2_rundir)
 
     continuous_checksums = _checksum_restart_files(continuous_rundir)
     segmented_checksums = _checksum_restart_files(segment_2_rundir)

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -124,7 +124,9 @@ def test_regression_native(run_native, config_filename: str, tmpdir, system_regt
 
 
 @pytest.mark.xfail(reason="https://github.com/ai2cm/fv3config/issues/147")
-@pytest.mark.parametrize("config_filename", ["default.yml", "emulation.yml"])
+@pytest.mark.parametrize(
+    "config_filename", ["default.yml", "emulation.yml", "restart.yml"]
+)
 def test_restart_reproducibility(run_native, config_filename, tmpdir):
     config_template = get_config(config_filename)
     config_template["diag_table"] = "no_output"

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -123,7 +123,7 @@ def test_regression_native(run_native, config_filename: str, tmpdir, system_regt
     _checksum_rundir(str(rundir), file=system_regtest)
 
 
-@pytest.mark.xfail(reason="https://github.com/ai2cm/fv3config/issues/147")
+# @pytest.mark.xfail(reason="https://github.com/ai2cm/fv3config/issues/147")
 @pytest.mark.parametrize(
     "config_filename", ["default.yml", "emulation.yml", "restart.yml"]
 )


### PR DESCRIPTION
This PR adds a test to ensure that segmented runs produce identical results to continuous runs for a series of configurations.  

### Dependency updates

For this test to pass, a change to fv3config was required (see more discussion in ai2cm/fv3config#147 and ai2cm/fv3config#144), which has been included in its latest release, v0.9.0.  Accordingly this PR bumps the versions of some dependencies in our testing environments:

- In the nix environment, fv3config is updated from version 0.7.1 to 0.9.0.
- In the default test environment, fv3config is updated to version 0.9.0 and fsspec and gcsfs are updated to their latest versions, 2022.3.0 and 2022.3.0.  Upgrading gcsfs to version 2022.3.0 also required updating the Python version to at least 3.7.0.  Without updating fsspec and gcsfs, the tests would fail to download the required input data ([build log](https://app.circleci.com/pipelines/github/ai2cm/fv3gfs-fortran/2109/workflows/abe08cb6-4f5f-42b2-80ad-0919fd39f0f8/jobs/3340)).

### Configuration updates

The update to fv3config brought with it one breaking change.  In order to use a set of restart files as an initial condition -- in contrast to using a set of restart files as a bridge between segments of a segmented run<sup>1</sup> -- one must set the `coupler_nml.current_date` to the date associated with the restart files and set `coupler_nml.force_date_from_namelist` to true.  

**We use restart files as an initial condition with the `restart.yml` configuration in the test suite, and therefore update its namelist parameters accordingly (see https://github.com/ai2cm/fv3gfs-fortran/pull/269/commits/b26041a4afb89733dea0b2d4565e1df203e1d5ae).  Please take note of this example if you use restart files as an initial condition elsewhere.**

-----

<sup>1</sup>When restart files are used as a bridge between segments, `coupler_nml.force_date_from_namelist` should be set to false, and `coupler_nml.current_date` is not used by the model.  In this case we recommend using `fv3config.enable_restart` to update an initial config for the next segment, because it will handle all configuration/namelist changes for you.