### PR TITLE
Fortran fix for reproducible restarts

### DIFF
--- a/FV3/coupler_main.F90
+++ b/FV3/coupler_main.F90
@@ -303,6 +303,7 @@ contains
          call error_mesg ('program coupler',  &
               'no namelist value for current_date', FATAL)
     else
+         date_init = current_date
          date      = current_date
     endif
 
@@ -353,11 +354,6 @@ contains
 !------ initialize diagnostics manager ------
 
     call diag_manager_init (TIME_INIT=date)
-
-!----- always override initial/base date with diag_manager value -----
-
-    call get_base_date ( date_init(1), date_init(2), date_init(3), &
-                         date_init(4), date_init(5), date_init(6)  )
 
 !----- use current date if no base date ------
 

--- a/tests/pytest/config/restart.yml
+++ b/tests/pytest/config/restart.yml
@@ -62,7 +62,7 @@ namelist:
     - 8
     - 1
     - 0
-    - 0
+    - 30
     - 0
     days: 0
     dt_atmos: 900
@@ -74,6 +74,7 @@ namelist:
     ncores_per_node: 32
     seconds: 0
     use_hyper_thread: true
+    force_date_from_namelist: true
   diag_manager_nml:
     prepend_date: false
   external_ic_nml:

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -1,3 +1,5 @@
+import copy
+import datetime
 import glob
 import os
 from os.path import join
@@ -7,6 +9,7 @@ import fv3config
 import numpy as np
 import xarray
 import subprocess
+import typing
 import hashlib
 
 import re
@@ -120,6 +123,39 @@ def test_regression_native(run_native, config_filename: str, tmpdir, system_regt
     _checksum_rundir(str(rundir), file=system_regtest)
 
 
+@pytest.mark.parametrize("config_filename", ["default.yml", "emulation.yml"])
+def test_restart_reproducibility(run_native, config_filename, tmpdir):
+    config_template = get_config(config_filename)
+    config_template["diag_table"] = "no_output"
+    config_template["namelist"]["gfs_physics_nml"]["fhswr"] = 900
+    config_template["namelist"]["gfs_physics_nml"]["fhlwr"] = 900
+
+    segment_1_config = copy.deepcopy(config_template)
+    segment_2_config = copy.deepcopy(config_template)
+    continuous_config = copy.deepcopy(config_template)
+
+    duration = datetime.timedelta(minutes=30)
+    segment_1_config = fv3config.set_run_duration(segment_1_config, duration // 2)
+    segment_2_config = fv3config.set_run_duration(segment_2_config, duration // 2)
+    continuous_config = fv3config.set_run_duration(continuous_config, duration)
+
+    segment_1_rundir = str(tmpdir.join("segment-1"))
+    segment_2_rundir = str(tmpdir.join("segment-2"))
+    continuous_rundir = str(tmpdir.join("continuous"))
+
+    run_native(segment_1_config, segment_1_rundir)
+    run_native(continuous_config, continuous_rundir)
+
+    segment_1_restarts = os.path.join(segment_1_rundir, "RESTART")
+    segment_2_config = fv3config.enable_restart(segment_2_config, segment_1_restarts)
+    run_native(segment_2_config, segment_2_rundir)
+
+    continuous_checksums = _checksum_restart_files(continuous_rundir)
+    segmented_checksums = _checksum_restart_files(segment_2_rundir)
+
+    assert segmented_checksums == continuous_checksums
+
+
 @pytest.fixture(scope="session")
 def emulation_run(run_native, tmpdir_factory):
     config = get_config("emulation.yml")
@@ -193,6 +229,11 @@ def checksum_file(path: str) -> str:
                 break
             sum.update(buf)
     return sum.hexdigest()
+
+
+def _checksum_restart_files(rundir: str) -> typing.Dict[str, str]:
+    restart_files = sorted(glob.glob(os.path.join(rundir, "RESTART", "*.nc")))
+    return {os.path.basename(file): checksum_file(file) for file in restart_files}
 
 
 def _checksum_rundir(rundir: str, file):


### PR DESCRIPTION
This illustrates a potential fortran alternative to ai2cm/fv3config#144.  This removes the dependence of the fortran model on the base date in the `diag_table`.  To preserve our workflow in starting from coarsened restart files in fv3net, it sets the initialization date to the date set in the namelist if `force_date_from_namelist` is set to true (overriding whatever it was in the `coupler.res` file in the coarsened restarts).  