### PR TITLE
Update python version used on daint for CI

### DIFF
--- a/.jenkins/actions/build_bare_metal.sh
+++ b/.jenkins/actions/build_bare_metal.sh
@@ -134,6 +134,7 @@ fi
 cd -
 
 # build venv for fv3config
+module load cray-python/3.8.5.0
 python3 -m venv ${rootdir}/venv
 source venv/bin/activate
 pip install -r ${rootdir}/requirements.txt


### PR DESCRIPTION
With the additional install of `gcsfs`, python version needs to be >3.7. Updating daint to use python 3.8.5.