### PR TITLE
data version 8.0.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,12 +25,6 @@ RUN wget -q http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz && \
 FROM $MPI_IMAGE AS mpi_image
 
 FROM $BASE_IMAGE AS fv3gfs-environment
-RUN rm /etc/apt/sources.list.d/cuda.list
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
-RUN apt-key del 7fa2af80
-RUN apt-get update && apt-get install -y --no-install-recommends wget
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt-get update && apt-get install -y \
     wget \
     gcc \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,12 @@ RUN wget -q http://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz && \
 FROM $MPI_IMAGE AS mpi_image
 
 FROM $BASE_IMAGE AS fv3gfs-environment
-
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN apt-key del 7fa2af80
+RUN apt-get update && apt-get install -y --no-install-recommends wget
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt-get update && apt-get install -y \
     wget \
     gcc \

--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -10,7 +10,7 @@ SER_ENV ?= dycore
 # -convention: <tag>-<some large conceptual version change>.<serialization statement change>.<hotfix>
 # -version number should be increased when serialization data is expected to change
 # -omit tag (e.g. 7.1.1) for "operational" serialization data, use tag for experimental serialization data
-FORTRAN_VERSION ?= 8.0.3
+FORTRAN_VERSION ?= 8.0.4
 # docker container image setup (used for running model, see ../../README.md)
 GCR_URL = us.gcr.io/vcm-ml
 COMPILED_IMAGE = $(GCR_URL)/fv3gfs-compiled:gnu7-mpich314-nocuda-serialize


### PR DESCRIPTION
UPDATE -- the fix is no longer needed, but we need a new data version number, the current one does not match 8.0.3
_A quick fix for a new error:
GPG error: https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F60F4B3D7FA2AF80
recommended here: 
https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
and here
https://github.com/NVIDIA/nvidia-docker/issues/1631_