### PR TITLE
FV3: fv_sat_adj tendency diags

### DIFF
--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -802,7 +802,8 @@ contains
                        Atm(n)%gridstruct,  Atm(n)%flagstruct,                    &
                        Atm(n)%neststruct,  Atm(n)%idiag, Atm(n)%bd,              &
                        Atm(n)%parent_grid, Atm(n)%domain,Atm(n)%diss_est,        &
-                       Atm(n)%lagrangian_tendency_of_hydrostatic_pressure)
+                       Atm(n)%lagrangian_tendency_of_hydrostatic_pressure,       &
+                       fv_sat_adj_tendency_diag=Atm(n)%fv_sat_adj_tendency_diag)
      !$ser verbatim if (serialize_physics .and. save_step) then
      ! NOTE: this is added here for convenience. In a future iteration
      ! you may want to save this after fv_subgridz, so that physics tests

--- a/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
+++ b/FV3/atmos_cubed_sphere/driver/fvGFS/atmosphere.F90
@@ -1978,7 +1978,9 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est,                                                  &
+                        Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure,                                  &
+                        fv_sat_adj_tendency_diag=Atm(mytile)%fv_sat_adj_tendency_diag)
 ! Backward
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, -dt_atmos, 0.,                &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -1993,7 +1995,9 @@ contains
                         Atm(mytile)%cx,    Atm(mytile)%cy,   Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,    &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est,                                                  &
+                        Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure,                                  &
+                        fv_sat_adj_tendency_diag=Atm(mytile)%fv_sat_adj_tendency_diag)
 !Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (pref, npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dp0, xt, zvir, mytile, nudge_dz, dz0) &
@@ -2070,7 +2074,9 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est,                                                  &
+                        Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure,                                  &
+                        fv_sat_adj_tendency_diag=Atm(mytile)%fv_sat_adj_tendency_diag)
 ! Forward call
        call fv_dynamics(Atm(mytile)%npx, Atm(mytile)%npy, npz,  nq, Atm(mytile)%ng, dt_atmos, 0.,                 &
                         Atm(mytile)%flagstruct%fill, Atm(mytile)%flagstruct%reproduce_sum, kappa, cp_air, zvir,   &
@@ -2085,7 +2091,9 @@ contains
                         Atm(mytile)%cx, Atm(mytile)%cy, Atm(mytile)%ze0, Atm(mytile)%flagstruct%hybrid_z,         &
                         Atm(mytile)%gridstruct, Atm(mytile)%flagstruct,                                           &
                         Atm(mytile)%neststruct, Atm(mytile)%idiag, Atm(mytile)%bd, Atm(mytile)%parent_grid,       &
-                        Atm(mytile)%domain,Atm(mytile)%diss_est, Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure)
+                        Atm(mytile)%domain,Atm(mytile)%diss_est,                                                  &
+                        Atm(mytile)%lagrangian_tendency_of_hydrostatic_pressure,                                  &
+                        fv_sat_adj_tendency_diag=Atm(mytile)%fv_sat_adj_tendency_diag)
 ! Nudging back to IC
 !$omp parallel do default (none) &
 !$omp              shared (nudge_dz,npz, jsc, jec, isc, iec, n, sphum, Atm, u0, v0, t0, dz0, dp0, xt, zvir, mytile) &

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -1430,10 +1430,10 @@ module fv_arrays_mod
   integer :: atmos_axes(4)
 
   type(nudge_diag_type) :: nudge_diag
-  
-  type(fv_sat_adj_tendency_diag_type) :: fv_sat_adj_tendency_diag
 
   type(physics_tendency_diag_type) :: physics_tendency_diag
+  
+  type(fv_sat_adj_tendency_diag_type) :: fv_sat_adj_tendency_diag
 
   type(fv_coarse_graining_type) :: coarse_graining
 

--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -117,6 +117,8 @@ module fv_arrays_mod
      integer :: id_u_dt_nudge, id_v_dt_nudge, id_q_dt_nudge
      integer :: id_t_dt_phys, id_qv_dt_phys, id_liq_wat_dt_phys, id_ice_wat_dt_phys
      integer :: id_qr_dt_phys, id_qs_dt_phys, id_qg_dt_phys
+     integer :: id_fv_sat_adj_t_dt, id_fv_sat_adj_qv_dt
+     integer :: id_column_fv_sat_adj_heating, id_column_fv_sat_adj_moistening
      integer :: id_column_moistening_nudge, id_column_heating_nudge
      integer :: id_column_eastward_acceleration_nudge, id_column_northward_acceleration_nudge
 
@@ -1171,6 +1173,16 @@ module fv_arrays_mod
       real, allocatable :: qg_dt(:,:,:)
 
    end type physics_tendency_diag_type
+   
+   type fv_sat_adj_tendency_diag_type
+
+      real, allocatable :: fv_sat_adj_t_dt(:,:,:)
+      real, allocatable :: fv_sat_adj_qv_dt(:,:,:)
+      real, allocatable :: column_fv_sat_adj_heating(:,:)
+      real, allocatable :: column_fv_sat_adj_moistening(:,:)
+      
+   end type fv_sat_adj_tendency_diag_type
+   
 !>@brief 'allocate_fv_nest_BC_type' is an interface to subroutines
 !! that allocate the 'fv_nest_BC_type' structure that holds the nested-grid BCs.
 !>@details The subroutines can pass the array bounds explicitly or not.
@@ -1418,6 +1430,8 @@ module fv_arrays_mod
   integer :: atmos_axes(4)
 
   type(nudge_diag_type) :: nudge_diag
+  
+  type(fv_sat_adj_tendency_diag_type) :: fv_sat_adj_tendency_diag
 
   type(physics_tendency_diag_type) :: physics_tendency_diag
 

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -897,11 +897,13 @@ contains
   
   if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
      fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt / bdt
+
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_heating)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt, &
            delp(isd:ied,jsd:jed,1:npz), &
            isd, ied, jsd, jed, npz, &
            fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed))
+
         if (hydrostatic) then
            fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed) = &
               cp_air * fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed)
@@ -914,6 +916,7 @@ contains
   
   if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
      fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt / bdt
+
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt, &
            delp(isd:ied,jsd:jed,1:npz), &

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -900,16 +900,15 @@ contains
 
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_heating)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt, &
-           delp(isd:ied,jsd:jed,1:npz), &
-           isd, ied, jsd, jed, npz, &
-           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed))
+           delp(is:ie,js:je,1:npz), &
+           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je))
 
         if (hydrostatic) then
-           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed) = &
-              cp_air * fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed)
+           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je) = &
+              cp_air * fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je)
         else
-           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed) = &
-              cv_air * fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isd:ied,jsd:jed)
+           fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je) = &
+              cv_air * fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je)
         endif
      endif
   endif
@@ -919,9 +918,8 @@ contains
 
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt, &
-           delp(isd:ied,jsd:jed,1:npz), &
-           isd, ied, jsd, jed, npz, &
-           fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening(isd:ied,jsd:jed))
+           delp(is:ie,js:je,1:npz), &
+           fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening(is:ie,js:je))
      endif
   endif
                                                   
@@ -1605,13 +1603,12 @@ contains
 
  end subroutine compute_aam
  
-
- subroutine compute_column_integral(integrand, delp, isd, ied, jsd, jed, npz, column_integral)
-    integer, intent(in) :: isd, ied, jsd, jed, npz
-    real, intent(in), dimension(isd:ied,jsd:jed,1:npz) :: integrand, delp
-    real, intent(out) :: column_integral(isd:ied,jsd:jed)
-
+ subroutine compute_column_integral(integrand, delp, column_integral)
+    real, intent(in), dimension(:,:,:) :: integrand, delp
+    real, intent(out) :: column_integral(:,:)
+    
   column_integral = sum(integrand * delp, 3) / grav
+  
  end subroutine compute_column_integral
 
 end module fv_dynamics_mod

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -147,6 +147,7 @@ module fv_dynamics_mod
    use fv_arrays_mod,       only: fv_grid_type, fv_flags_type, fv_atmos_type, fv_nest_type, & 
                                   fv_diag_type, fv_grid_bounds_type, fv_sat_adj_tendency_diag_type
    use fv_nwp_nudge_mod,    only: do_adiabatic_init
+   use fv_update_phys_mod,  only: compute_column_integral
 #ifdef MULTI_GASES
    use multi_gases_mod,     only:  virq, virqd, vicpqd
 #endif
@@ -901,6 +902,7 @@ contains
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_heating)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt, &
            delp(is:ie,js:je,1:npz), &
+           is, ie, js, je, npz, &
            fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(is:ie,js:je))
 
         if (hydrostatic) then
@@ -919,6 +921,7 @@ contains
      if (allocated(fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening)) then
         call compute_column_integral(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt, &
            delp(is:ie,js:je,1:npz), &
+           is, ie, js, je, npz, &
            fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening(is:ie,js:je))
      endif
   endif
@@ -1602,13 +1605,5 @@ contains
   enddo
 
  end subroutine compute_aam
- 
- subroutine compute_column_integral(integrand, delp, column_integral)
-    real, intent(in), dimension(:,:,:) :: integrand, delp
-    real, intent(out) :: column_integral(:,:)
-    
-  column_integral = sum(integrand * delp, 3) / grav
-  
- end subroutine compute_column_integral
 
 end module fv_dynamics_mod

--- a/FV3/atmos_cubed_sphere/model/fv_mapz.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_mapz.F90
@@ -962,7 +962,9 @@ endif        ! end last_step check
 !$ser data dpln=dpln peln=peln mdt=mdt r_vir=r_vir fast_mp_consv=fast_mp_consv te=te  qvapor=q(:,:,:,sphum) qliquid=q(:,:,:,liq_wat) qice=q(:,:,:,ice_wat) qrain=q(:,:,:,rainwat) qsnow=q(:,:,:,snowwat) qgraupel=q(:,:,:,graupel)  qcld=q(:,:,:,cld_amt)  hs=hs delz=delz pt=pt delp=delp q_con=q_con cappa=cappa  out_dt=out_dt last_step=last_step  pkz=pkz rrg=rrg akap=akap kmp=kmp pfull=pfull
 
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
-       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt - pt(isd:ied,jsd:jed,:)
+       ! convert to temperature from virtual temperature for tendency computation
+       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt - &
+                                                  (pt(isd:ied,jsd:jed,:) / (1 + r_vir * q(isd:ied,jsd:jed,:,sphum)))
     endif
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
        fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt - q(isd:ied,jsd:jed,:,sphum)
@@ -1010,7 +1012,9 @@ endif        ! end last_step check
            enddo    ! OpenMP k-loop
 
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
-       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt + pt(isd:ied,jsd:jed,:)
+       ! convert to temperature from virtual temperature for tendency computation
+       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt + &
+                                                  (pt(isd:ied,jsd:jed,:) / (1 + r_vir * q(isd:ied,jsd:jed,:,sphum)))
     endif
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
        fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt + q(isd:ied,jsd:jed,:,sphum)

--- a/FV3/atmos_cubed_sphere/model/fv_mapz.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_mapz.F90
@@ -964,10 +964,10 @@ endif        ! end last_step check
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
        ! convert to temperature from virtual temperature for tendency computation
        fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt - &
-                                                  (pt(isd:ied,jsd:jed,:) / (1 + r_vir * q(isd:ied,jsd:jed,:,sphum)))
+                                                  (pt(is:ie,js:je,:) / (1 + r_vir * q(is:ie,js:je,:,sphum)))
     endif
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
-       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt - q(isd:ied,jsd:jed,:,sphum)
+       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt - q(is:ie,js:je,:,sphum)
     endif
 
 !$OMP do
@@ -1014,10 +1014,10 @@ endif        ! end last_step check
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
        ! convert to temperature from virtual temperature for tendency computation
        fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt + &
-                                                  (pt(isd:ied,jsd:jed,:) / (1 + r_vir * q(isd:ied,jsd:jed,:,sphum)))
+                                                  (pt(is:ie,js:je,:) / (1 + r_vir * q(is:ie,js:je,:,sphum)))
     endif
     if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
-       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt + q(isd:ied,jsd:jed,:,sphum)
+       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt + q(is:ie,js:je,:,sphum)
     endif
 
 !$ser savepoint SatAdjust3d-Out

--- a/FV3/atmos_cubed_sphere/model/fv_mapz.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_mapz.F90
@@ -89,7 +89,7 @@ module fv_mapz_mod
   use fv_fill_mod,       only: fillz
   use mpp_domains_mod,   only: mpp_update_domains, domain2d
   use mpp_mod,           only: NOTE, FATAL, mpp_error, get_unit, mpp_root_pe, mpp_pe
-  use fv_arrays_mod,     only: fv_grid_type
+  use fv_arrays_mod,     only: fv_grid_type, fv_sat_adj_tendency_diag_type
   use fv_timing_mod,     only: timing_on, timing_off
   use fv_mp_mod,         only: is_master
 #ifndef CCPP
@@ -140,7 +140,7 @@ contains
                       nq, nwat, sphum, q_con, u, v, w, delz, pt, q, hs, r_vir, cp,  &
                       akap, cappa, kord_mt, kord_wz, kord_tr, kord_tm,  peln, te0_2d,        &
                       ng, ua, va, omga, te, ws, fill, reproduce_sum, out_dt, dtdt,      &
-                      ptop, ak, bk, pfull, gridstruct, domain, do_sat_adj, &
+                      ptop, ak, bk, pfull, gridstruct, domain, do_sat_adj, fv_sat_adj_tendency_diag, &
                       hydrostatic, hybrid_z, do_omega, adiabatic, do_adiabatic_init, lagrangian_tendency_of_hydrostatic_pressure)
   logical, intent(in):: last_step
   real,    intent(in):: mdt                    !< remap time step
@@ -203,6 +203,7 @@ contains
   real, intent(out)::    pkz(is:ie,js:je,km)       !< layer-mean pk for converting t to pt
   real, intent(out)::     te(isd:ied,jsd:jed,km)
   
+  type(fv_sat_adj_tendency_diag_type), intent(inout) :: fv_sat_adj_tendency_diag
 
 ! !DESCRIPTION:
 !
@@ -787,7 +788,7 @@ if (allocated(lagrangian_tendency_of_hydrostatic_pressure)) allocate(vulcan_pe3(
 !$OMP                               do_adiabatic_init,zsum1,zsum0,te0_2d,domain,               &
 !$OMP                               ng,gridstruct,E_Flux,pdt,dtmp,reproduce_sum,q,             &
 !$OMP                               mdt,cld_amt,cappa,dtdt,out_dt,rrg,akap,do_sat_adj,         &
-!$OMP                               fast_mp_consv,kord_tm)                                     &
+!$OMP                               fast_mp_consv,kord_tm, fv_sat_adj_tendency_diag)           &
 #ifdef MULTI_GASES
 !$OMP                        shared(num_gas)                                                   &
 #endif
@@ -955,9 +956,18 @@ endif        ! end last_step check
       call mpp_error (FATAL, 'Lagrangian_to_Eulerian: can not call CCPP fast physics because cdata not initialized')
     endif
 #else
+
     
 !$ser savepoint SatAdjust3d-In
 !$ser data dpln=dpln peln=peln mdt=mdt r_vir=r_vir fast_mp_consv=fast_mp_consv te=te  qvapor=q(:,:,:,sphum) qliquid=q(:,:,:,liq_wat) qice=q(:,:,:,ice_wat) qrain=q(:,:,:,rainwat) qsnow=q(:,:,:,snowwat) qgraupel=q(:,:,:,graupel)  qcld=q(:,:,:,cld_amt)  hs=hs delz=delz pt=pt delp=delp q_con=q_con cappa=cappa  out_dt=out_dt last_step=last_step  pkz=pkz rrg=rrg akap=akap kmp=kmp pfull=pfull
+
+    if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
+       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt - pt(isd:ied,jsd:jed,:)
+    endif
+    if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
+       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt - q(isd:ied,jsd:jed,:,sphum)
+    endif
+
 !$OMP do
            do k=kmp,km
               do j=js,je
@@ -998,6 +1008,14 @@ endif        ! end last_step check
                  enddo
               endif
            enddo    ! OpenMP k-loop
+
+    if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_t_dt)) then
+       fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = fv_sat_adj_tendency_diag%fv_sat_adj_t_dt + pt(isd:ied,jsd:jed,:)
+    endif
+    if (allocated(fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt)) then
+       fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt + q(isd:ied,jsd:jed,:,sphum)
+    endif
+
 !$ser savepoint SatAdjust3d-Out
 !$ser data dpln=dpln peln=peln te=te  qvapor=q(:,:,:,sphum) qliquid=q(:,:,:,liq_wat) qice=q(:,:,:,ice_wat) qrain=q(:,:,:,rainwat) qsnow=q(:,:,:,snowwat) qgraupel=q(:,:,:,graupel)  qcld=q(:,:,:,cld_amt)  delz=delz pt=pt delp=delp q_con=q_con cappa=cappa   pkz=pkz
 

--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -123,7 +123,7 @@ module fv_update_phys_mod
 
   implicit none
 
-  public :: fv_update_phys, del2_phys
+  public :: fv_update_phys, del2_phys, compute_column_integral
 #ifdef ROT3
   public :: update_dwinds_phys
 #endif

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -3350,6 +3350,21 @@ contains
         used = send_data(idiag%id_qg_dt_phys, Atm(n)%physics_tendency_diag%qg_dt(isc:iec,jsc:jec,1:npz), Time)
      endif
 
+     if (idiag%id_fv_sat_adj_t_dt > 0) then
+        used = send_data(idiag%id_fv_sat_adj_t_dt, Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_t_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_fv_sat_adj_qv_dt > 0) then
+        used = send_data(idiag%id_fv_sat_adj_qv_dt, Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt(isc:iec,jsc:jec,1:npz), Time)
+     endif
+     if (idiag%id_column_fv_sat_adj_heating > 0) then
+        used = send_data(idiag%id_column_fv_sat_adj_heating, &
+                         Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isc:iec,jsc:jec), Time)
+     endif
+     if (idiag%id_column_fv_sat_adj_moistening > 0) then
+        used = send_data(idiag%id_column_fv_sat_adj_moistening, &
+                         Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening(isc:iec,jsc:jec), Time)
+     endif
+
    ! enddo  ! end ntileMe do-loop
 
     deallocate ( a2 )

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -1233,7 +1233,49 @@ contains
          allocate(Atm(n)%physics_tendency_diag%qg_dt(isc:iec,jsc:jec,npz))
          Atm(n)%physics_tendency_diag%qg_dt = 0.0
     endif
-
+    
+    
+    !---------------------------------------
+    ! fast saturation adjustment diagnostics
+    !---------------------------------------
+    
+    idiag%id_fv_sat_adj_t_dt = register_diag_field('dynamics', &
+          'fv_sat_adj_t_dt', axes(1:3), Time, &
+          'temperature tendency from dynamics fast saturation adjustment', 'K/s', &
+          missing_value=missing_value)
+    if (idiag%id_fv_sat_adj_t_dt > 0) then
+         allocate(Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_t_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_t_dt = 0.0
+    endif
+    
+    idiag%id_fv_sat_adj_qv_dt = register_diag_field('dynamics', &
+          'fv_sat_adj_qv_dt', axes(1:3), Time, &
+          'specific humidity tendency from dynamics fast saturation adjustment', 'kg/kg/s', &
+          missing_value=missing_value)
+    if (idiag%id_fv_sat_adj_qv_dt > 0) then
+         allocate(Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt(isc:iec,jsc:jec,npz))
+         Atm(n)%fv_sat_adj_tendency_diag%fv_sat_adj_qv_dt = 0.0
+    endif
+    
+    idiag%id_column_fv_sat_adj_heating = register_diag_field('dynamics', &
+          'column_fv_sat_adj_heating', axes(1:2), Time, &
+          'column integrated heating from dynamics fast saturation adjustment', 'W/m**2', &
+          missing_value=missing_value)
+    if (idiag%id_column_fv_sat_adj_heating > 0) then
+         allocate(Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_heating(isc:iec,jsc:jec))
+         Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_heating = 0.0
+    endif
+    
+    idiag%id_column_fv_sat_adj_moistening = register_diag_field('dynamics', &
+          'column_fv_sat_adj_moistening', axes(1:2), Time, &
+          'column integrated moistening from dynamics fast saturation adjustment', 'mm/s', &
+          missing_value=missing_value)
+    if (idiag%id_column_fv_sat_adj_moistening > 0) then
+         allocate(Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening(isc:iec,jsc:jec))
+         Atm(n)%fv_sat_adj_tendency_diag%column_fv_sat_adj_moistening = 0.0
+    endif
+    
+    
     do tracer_index = 1, ncnst
       call get_tracer_names (MODEL_ATMOS, tracer_index, tname, tlongname, tunits)
       idiag%id_vertically_integrated_tracers(tracer_index) = register_diag_field (field, &

--- a/README.md
+++ b/README.md
@@ -195,9 +195,13 @@ Then configure the build to use nix
 
     cd FV3 && ./configure nix
 
-And build the model (with coverage outputs)
+And build the model (with coverage outputs, from the root directory)
 
     make build_native
+    
+And the wrapper
+
+    make -C FV3 wrapper_build
 
 At this point you can run [the native tests](#native-tests).
 # Testing the model
@@ -222,6 +226,8 @@ tests like this:
     make test_native
     # or manually
     pytest --native tests/pytest
+    # and 
+    pytest FV3/wrapper/tests/
 
 When using the makefile target, code coverages reports will be saved to the
 folder `coverage_<timestamp>`.


### PR DESCRIPTION
This PR adds 2D and 3D temperature and specific humidity tendency diagnostics from the dycore fast saturation adjustment. FV3GFS didn't previously output these tendencies, which made computing complete "physics" tendencies difficult in the context of diagnostic budgets. 

See notebook [here](https://github.com/ai2cm/explore/blob/master/brianh/2022-05-06-N2F-40-day-Q-comparison/2022-05-16-debug-fast-sat-adj-diags.ipynb) that plots the mean 2D and 3D diagnostics output from a 10-day nudged run. For reference, the column moistening tendencies look like about the same (but sign flipped) pattern as what we [inferred (see Figure 8 bottom panel)](https://docs.google.com/document/d/1-bHzB75TD7nhhWF4TnZAoKhweCgKEgXDkZ12TV2Cw4g/edit#heading=h.1dkyg7nqpvqg) to be missing fast saturation adjustment drying tendencies from previous 40-day nudged runs. 

Resolves #291.