### PR TITLE
Add compression to converted netcdf data, install deps in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -235,8 +235,10 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip && \
     ln -s /bin/python3 /bin/python && \
-    ln -s /bin/pip3 /bin/pip && \
-    pip3 install --no-cache-dir pyyaml
+    ln -s /bin/pip3 /bin/pip
+# install python packages needed to convert to netcdf data
+RUN pip3 install --upgrade setuptools pip && \
+    pip3 install --no-cache-dir pyyaml xarray==0.16.2 f90nml==1.1.0 netCDF4
 
 # run model
 CMD ["bash", "/rundir/submit_job.sh"]

--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -91,10 +91,10 @@ pack_data: ## convert to netcdf files, pack *.dat files into a *.tar.gz and dele
 		echo "Error: Tar file $(TARFILE_HOST) already exists. Already packed?" ; \
 		exit 1 ; \
 	fi
-	docker run --mount type=bind,source=$(shell pwd)/serialbox_to_netcdf.py,target=/root/serialbox_to_netcdf.py -v $(DATA_DIR_HOST):/data -it $(COMPILED_IMAGE) bash -c "pip3 install xarray==0.16.2 f90nml==1.1.0 scipy==1.5.4 && python3 /root/serialbox_to_netcdf.py /data /data"
-	cd $(DATA_DIR_HOST) && \
-		tar -cvzf $(TARFILE_HOST) *.dat > $(TARFILE_INDEX_HOST) && \
-		rm -f *.dat ; \
+	docker run --mount type=bind,source=$(shell pwd)/serialbox_to_netcdf.py,target=/root/serialbox_to_netcdf.py -v $(DATA_DIR_HOST):/data -it $(COMPILED_IMAGE) bash -c "python3 /root/serialbox_to_netcdf.py /data /data"
+	# cd $(DATA_DIR_HOST) && \
+	# 	tar -cvzf $(TARFILE_HOST) *.dat > $(TARFILE_INDEX_HOST) && \
+	# 	rm -f *.dat ; \
 
 unpack_data: ## unpack *.dat files from a *.tar.gz and remove tar-file
 	@echo ""

--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -92,9 +92,9 @@ pack_data: ## convert to netcdf files, pack *.dat files into a *.tar.gz and dele
 		exit 1 ; \
 	fi
 	docker run --mount type=bind,source=$(shell pwd)/serialbox_to_netcdf.py,target=/root/serialbox_to_netcdf.py -v $(DATA_DIR_HOST):/data -it $(COMPILED_IMAGE) bash -c "python3 /root/serialbox_to_netcdf.py /data /data"
-	# cd $(DATA_DIR_HOST) && \
-	# 	tar -cvzf $(TARFILE_HOST) *.dat > $(TARFILE_INDEX_HOST) && \
-	# 	rm -f *.dat ; \
+	cd $(DATA_DIR_HOST) && \
+		tar -cvzf $(TARFILE_HOST) *.dat > $(TARFILE_INDEX_HOST) && \
+		rm -f *.dat ; \
 
 unpack_data: ## unpack *.dat files from a *.tar.gz and remove tar-file
 	@echo ""

--- a/tests/serialized_test_data_generation/serialbox_to_netcdf.py
+++ b/tests/serialized_test_data_generation/serialbox_to_netcdf.py
@@ -77,13 +77,19 @@ def main(data_path: str, output_path: str):
         n_savepoints = len(savepoints)  # checking from last rank is fine
         data_vars = {}
         if n_savepoints > 0:
+            encoding = {}
             for varname in set(names_list).difference(["rank"]):
                 data_shape = list(rank_list[0][varname][0].shape)
                 data_vars[varname] = get_data(
                     data_shape, total_ranks, n_savepoints, rank_list, varname
                 )
+                if len(data_shape) > 2:
+                    encoding[varname] = {"zlib": True, "complevel": 1}
             dataset = xr.Dataset(data_vars=data_vars)
-            dataset.to_netcdf(os.path.join(output_path, f"{savepoint_name}.nc"))
+            dataset.to_netcdf(
+                os.path.join(output_path, f"{savepoint_name}.nc"),
+                encoding=encoding
+            )
 
 
 def get_data(data_shape, total_ranks, n_savepoints, output_list, varname):


### PR DESCRIPTION
This PR adds compression of greater than 2D variables to serialbox_to_netcdf.py, reducing output file sizes by about 40%. It also installs the python dependencies required within the docker image, reducing the time needed when converting data.