### PR TITLE
Generate 8.1.0 data with netcdf files

### DIFF
--- a/tests/serialized_test_data_generation/Makefile
+++ b/tests/serialized_test_data_generation/Makefile
@@ -10,7 +10,7 @@ SER_ENV ?= dycore
 # -convention: <tag>-<some large conceptual version change>.<serialization statement change>.<hotfix>
 # -version number should be increased when serialization data is expected to change
 # -omit tag (e.g. 7.1.1) for "operational" serialization data, use tag for experimental serialization data
-FORTRAN_VERSION ?= 8.0.5
+FORTRAN_VERSION ?= 8.1.0
 # docker container image setup (used for running model, see ../../README.md)
 GCR_URL = us.gcr.io/vcm-ml
 COMPILED_IMAGE = $(GCR_URL)/fv3gfs-compiled:gnu7-mpich314-nocuda-serialize


### PR DESCRIPTION
We bump the version to 8.1.0 now that the serialized data also include netcdf format.