### PR TITLE
Set the model to output physics diagnostics indefinitely by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: nix-shell --run "make -j 4 -C FV3 wrapper_build"
       - run:
           name: Test
-          command: nix-shell --run "pytest --native tests/pytest"
+          command: nix-shell --run "pytest --native tests/pytest -v"
       - run:
           name: Test wrapper
           command: nix-shell --run "make test_wrapper"

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -184,11 +184,6 @@ integer, parameter     :: maxhr = 65536
 real, dimension(maxhr) :: fdiag = 0.
 real                   :: fhmax=384.0, fhmaxhf=120.0, fhout=3.0, fhouthf=1.0,avg_max_length=3600.
 
-! By default, as of https://github.com/ai2cm/fv3gfs-fortran/issues/302, the
-! physics diagnostics will be configured to be output indefinitely at a regular
-! interval of fhout hours, ignoring any values set for fdiag, fhmax, fhmaxhf, or
-! fhouthf.
-!
 ! To restore previous behavior and output diagnostics following what is
 ! prescribed by the fdiag, fhmax, fhmaxhf, fhout, and fhouthf parameters, set
 ! the use_fdiag flag to .true.

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -184,21 +184,20 @@ integer, parameter     :: maxhr = 65536
 real, dimension(maxhr) :: fdiag = 0.
 real                   :: fhmax=384.0, fhmaxhf=120.0, fhout=3.0, fhouthf=1.0,avg_max_length=3600.
 
-! By default, if fdiag is provided as a scalar value and fhouthf < 0, the
-! physics diagnostics will be output on regular intervals of length fhout hours
-! for a finite number of total simulated hours, governed by fhmax. See
-! https://github.com/ai2cm/fv3gfs-fortran/issues/301 for more details.
+! By default, as of https://github.com/ai2cm/fv3gfs-fortran/issues/302, the
+! physics diagnostics will be configured to be output indefinitely at a regular
+! interval of fhout hours, ignoring any values set for fdiag, fhmax, fhmaxhf, or
+! fhouthf.
 !
-! To override this behavior, and output physics diagnostics on a regular
-! interval of fhout hours indefinitely, set the
-! output_physics_diagnostics_indefinitely flag to .true. Naturally this will
-! ignore any values set for fdiag, fhmax, fhmaxhf, or fhouthf.
-logical :: output_physics_diagnostics_indefinitely = .false.  
+! To restore previous behavior and output diagnostics following what is
+! prescribed by the fdiag, fhmax, fhmaxhf, fhout, and fhouthf parameters, set
+! the use_fdiag flag to .true.
+logical :: use_fdiag = .false.  
 
 #ifdef CCPP
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, ccpp_suite, avg_max_length, output_physics_diagnostics_indefinitely
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, ccpp_suite, avg_max_length, use_fdiag
 #else
-namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, avg_max_length, output_physics_diagnostics_indefinitely
+namelist /atmos_model_nml/ blocksize, chksum_debug, dycore_only, debug, sync, fdiag, fhmax, fhmaxhf, fhout, fhouthf, disable_phys_restart_write, avg_max_length, use_fdiag
 #endif
 
 type (time_type) :: diag_time, diag_time_fhzero
@@ -941,8 +940,8 @@ subroutine update_atmos_model_state (Atmos)
       Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
       IPD_Diag_coarse, Atm(mytile)%delp(is:ie,js:je,:), &
       Atmos%coarsening_strategy, Atm(mytile)%ptop)
-    is_diagnostics_time = ((.not. output_physics_diagnostics_indefinitely) .and. (ANY(nint(fdiag(:)*3600.0) == seconds))) .or. &
-                          (output_physics_diagnostics_indefinitely .and. (mod(seconds, nint(fhout * 3600.0)) == 0))
+    is_diagnostics_time = (use_fdiag .and. (ANY(nint(fdiag(:)*3600.0) == seconds))) .or. &
+                          ((.not. use_fdiag) .and. (mod(seconds, nint(fhout * 3600.0)) == 0))
     if (is_diagnostics_time .or. (IPD_Control%kdt == first_kdt) .or. nsout > 0) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)

--- a/FV3/atmos_model.F90
+++ b/FV3/atmos_model.F90
@@ -910,6 +910,7 @@ subroutine update_atmos_model_state (Atmos)
   integer :: rc
   real(kind=IPD_kind_phys) :: time_int, time_intfull
   integer :: is, ie, js, je, nk
+  logical :: is_diagnostics_time
 !
     call mpp_clock_begin(otherClock)
     call set_atmosphere_pelist()
@@ -940,7 +941,9 @@ subroutine update_atmos_model_state (Atmos)
       Atm(mytile)%coarse_graining%write_coarse_diagnostics, &
       IPD_Diag_coarse, Atm(mytile)%delp(is:ie,js:je,:), &
       Atmos%coarsening_strategy, Atm(mytile)%ptop)
-    if (((.not. output_physics_diagnostics_indefinitely) .and. (ANY(nint(fdiag(:)*3600.0) == seconds))) .or. (output_physics_diagnostics_indefinitely .and. (mod(seconds, nint(fhout * 3600.0)) == 0)) .or. (IPD_Control%kdt == first_kdt) .or. nsout > 0) then
+    is_diagnostics_time = ((.not. output_physics_diagnostics_indefinitely) .and. (ANY(nint(fdiag(:)*3600.0) == seconds))) .or. &
+                          (output_physics_diagnostics_indefinitely .and. (mod(seconds, nint(fhout * 3600.0)) == 0))
+    if (is_diagnostics_time .or. (IPD_Control%kdt == first_kdt) .or. nsout > 0) then
       if (mpp_pe() == mpp_root_pe()) write(6,*) "---isec,seconds",isec,seconds
       time_int = real(isec)
       if(Atmos%iau_offset > zero) then

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -161,9 +161,6 @@ def test_indefinite_physics_diagnostics(run_native, tmpdir):
 
     fdiag = copy.deepcopy(config_template)
     fdiag["namelist"]["atmos_model_nml"]["fhout"] = 0.5
-    # We have made the choice to set use_fdiag to .false. by default, since we
-    # prefer to output physics diagnostics indefinitely; therefore to restore
-    # the original behavior, we must set use_fdiag to .true.
     fdiag["namelist"]["atmos_model_nml"]["use_fdiag"] = True
 
     indefinite = copy.deepcopy(config_template)

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -156,6 +156,31 @@ def test_restart_reproducibility(run_native, config_filename, tmpdir):
     assert segmented_checksums == continuous_checksums
 
 
+def test_output_physics_diagnostics_indefinitely_flag(run_native, tmpdir):
+    config_template = get_config("default.yml")
+
+    default = copy.deepcopy(config_template)
+    default["namelist"]["atmos_model_nml"]["fhout"] = 0.5
+
+    indefinite = copy.deepcopy(config_template)
+    indefinite["namelist"]["atmos_model_nml"]["fhout"] = 0.5
+    indefinite["namelist"]["atmos_model_nml"]["output_physics_diagnostics_indefinitely"] = True
+    # No change is required to the fhmax parameter here, but this is just to
+    # demonstrate that with the output_physics_diagnostics_indefinitely = .true.
+    # option, the value of fhmax is ignored and physics diagnostics are output
+    # indefinitely.
+    indefinite["namelist"]["atmos_model_nml"]["fhmax"] = 0.0
+
+    default_rundir = str(tmpdir.join("default"))
+    indefinite_rundir = str(tmpdir.join("indefinite"))
+    run_native(default, default_rundir)
+    run_native(indefinite, indefinite_rundir)
+
+    default_checksums =  _checksum_diagnostics(default_rundir)
+    indefinite_checksums = _checksum_diagnostics(indefinite_rundir)
+    assert default_checksums == indefinite_checksums
+
+
 @pytest.fixture(scope="session")
 def emulation_run(run_native, tmpdir_factory):
     config = get_config("emulation.yml")
@@ -234,6 +259,11 @@ def checksum_file(path: str) -> str:
 def _checksum_restart_files(rundir: str) -> typing.Dict[str, str]:
     restart_files = sorted(glob.glob(os.path.join(rundir, "RESTART", "*.nc")))
     return {os.path.basename(file): checksum_file(file) for file in restart_files}
+
+
+def _checksum_diagnostics(rundir: str):
+    files = glob.glob(os.path.join(rundir, "*.nc"))
+    return {os.path.basename(file): checksum_file(file) for file in files}
 
 
 def _checksum_rundir(rundir: str, file):

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -156,29 +156,31 @@ def test_restart_reproducibility(run_native, config_filename, tmpdir):
     assert segmented_checksums == continuous_checksums
 
 
-def test_output_physics_diagnostics_indefinitely_flag(run_native, tmpdir):
+def test_indefinite_physics_diagnostics(run_native, tmpdir):
     config_template = get_config("default.yml")
 
-    default = copy.deepcopy(config_template)
-    default["namelist"]["atmos_model_nml"]["fhout"] = 0.5
+    fdiag = copy.deepcopy(config_template)
+    fdiag["namelist"]["atmos_model_nml"]["fhout"] = 0.5
+    # We have made the choice to set use_fdiag to .false. by default, since we
+    # prefer to output physics diagnostics indefinitely; therefore to restore
+    # the original behavior, we must set use_fdiag to .true.
+    fdiag["namelist"]["atmos_model_nml"]["use_fdiag"] = True
 
     indefinite = copy.deepcopy(config_template)
     indefinite["namelist"]["atmos_model_nml"]["fhout"] = 0.5
-    indefinite["namelist"]["atmos_model_nml"]["output_physics_diagnostics_indefinitely"] = True
     # No change is required to the fhmax parameter here, but this is just to
-    # demonstrate that with the output_physics_diagnostics_indefinitely = .true.
-    # option, the value of fhmax is ignored and physics diagnostics are output
-    # indefinitely.
+    # demonstrate that with the use_fdiag = .false. option, the value of fhmax is
+    # ignored and physics diagnostics are output indefinitely.
     indefinite["namelist"]["atmos_model_nml"]["fhmax"] = 0.0
 
-    default_rundir = str(tmpdir.join("default"))
+    fdiag_rundir = str(tmpdir.join("fdiag"))
     indefinite_rundir = str(tmpdir.join("indefinite"))
-    run_native(default, default_rundir)
+    run_native(fdiag, fdiag_rundir)
     run_native(indefinite, indefinite_rundir)
 
-    default_checksums =  _checksum_diagnostics(default_rundir)
+    fdiag_checksums =  _checksum_diagnostics(fdiag_rundir)
     indefinite_checksums = _checksum_diagnostics(indefinite_rundir)
-    assert default_checksums == indefinite_checksums
+    assert fdiag_checksums == indefinite_checksums
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Originally, by default, if `fdiag` was provided as a scalar value and `fhouthf`  was less than zero, the physics diagnostics would be output on regular intervals of length `fhout` hours for a finite number of total simulated hours, governed by `fhmax`.  This can be problematic in long simulations.  Simply using a large default value of `fhmax` is not tenable, because we cannot allocate an infinitely large `fdiag` array (which is what the original physics diagnostics approach uses under the hood).  

This PR changes the default behavior such that physics diagnostics will now be output indefinitely on a regular interval of `fhout` hours, ignoring any values set for the `fdiag`, `fhmax`, `fhmaxhf`, or `fhouthf` parameters.

While in practice we do not use the ability of `fdiag` to output physics diagnostics on irregular intervals, if one would like to restore this behavior, one can set the `atmos_model_nml.use_fdiag` namelist flag added in this PR to `.true.`.  Naturally the model will then use the parameters specified for `fdiag`, `fhmax`, `fhmaxhf`, and `fhouthf` in conjunction with `fhout` to determine when and how long to output physics diagnostics.

Resolves #301.