### PR TITLE
Make scaling initial qvapor a namelist option

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_control.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_control.F90
@@ -143,7 +143,7 @@ module fv_control_mod
    use fv_mp_mod,           only: ng, switch_current_Atm
    use fv_mp_mod,           only: broadcast_domains, mp_barrier, is_master, setup_master
 !!! CLEANUP: should be replaced by a getter function?
-   use test_cases_mod,      only: test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size
+   use test_cases_mod,      only: test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size, q0_baroclinic
    use fv_timing_mod,       only: timing_on, timing_off, timing_init, timing_prt
    use mpp_domains_mod,     only: domain2D
    use mpp_domains_mod,     only: mpp_define_nest_domains, nest_domain_type, mpp_get_global_domain
@@ -696,7 +696,7 @@ module fv_control_mod
                          restart_from_agrid_winds, write_optional_dgrid_vel_rst, &
                          write_coarse_dgrid_vel_rst, write_coarse_agrid_vel_rst
 
-   namelist /test_case_nml/test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size
+   namelist /test_case_nml/test_case, bubble_do, alpha, nsolitons, soliton_Umax, soliton_size, q0_baroclinic
 #ifdef MULTI_GASES
    namelist /multi_gases_nml/ rilist,cpilist
 #endif
@@ -708,6 +708,7 @@ module fv_control_mod
    alpha = 0.
    bubble_do = .false.
    test_case = 11   ! (USGS terrain)
+   q0_baroclinic = 0.021
 
 #ifdef INTERNAL_FILE_NML
 ! Read Main namelist

--- a/FV3/atmos_cubed_sphere/tools/test_cases.F90
+++ b/FV3/atmos_cubed_sphere/tools/test_cases.F90
@@ -175,6 +175,7 @@
       real    :: alpha
       integer :: Nsolitons
       real    :: soliton_size = 750.e3, soliton_Umax = 50.
+      real    :: q0_baroclinic
 
 ! Case 0 parameters
       real :: p0_c0 = 3.0
@@ -223,7 +224,7 @@
      integer, parameter :: interpOrder = 1
 
       public :: pz0, zz0
-      public :: test_case, bubble_do, alpha, tracer_test, wind_field, nsolitons, soliton_Umax, soliton_size
+      public :: test_case, bubble_do, alpha, tracer_test, wind_field, nsolitons, soliton_Umax, soliton_size, q0_baroclinic
       public :: init_case, get_stats, check_courant_numbers
 #ifdef NCDF_OUTPUT
       public :: output, output_ncdf
@@ -1755,7 +1756,7 @@
          sphum = get_tracer_index (MODEL_ATMOS, 'sphum')
          pcen(1) = PI/9.
          pcen(2) = 2.0*PI/9. 
-!$OMP parallel do default(none) shared(sphum,is,ie,js,je,npz,pe,q,agrid,pcen,delp,peln) &
+!$OMP parallel do default(none) shared(sphum,is,ie,js,je,npz,pe,q,agrid,pcen,delp,peln,q0_baroclinic) &
 !$OMP                          private(ptmp) 
          do k=1,npz
          do j=js,je
@@ -1764,7 +1765,7 @@
             !ptmp = 0.5*(pe(i,k,j)+pe(i,k+1,j)) - 100000.
             !q(i,j,k,1) = 0.021*exp(-(agrid(i,j,2)/pcen(2))**4.)*exp(-(ptmp/34000.)**2.)
             ptmp = delp(i,j,k)/(peln(i,k+1,j)-peln(i,k,j)) - 100000.
-            q(i,j,k,sphum) = 0.021*exp(-(agrid(i,j,2)/pcen(2))**4.)*exp(-(ptmp/34000.)**2.)
+            q(i,j,k,sphum) = q0_baroclinic*exp(-(agrid(i,j,2)/pcen(2))**4.)*exp(-(ptmp/34000.)**2.)
 ! SJL:
 !           q(i,j,k,sphum) = max(1.e-25, q(i,j,k,sphum))
          enddo


### PR DESCRIPTION
When running baroclinic test case, we would like to control how much water vapor is initialized. `q0_baroclinic` is now a namelist option to increase/decrease the amount of qvapor for this test case.