### PR TITLE
wrapper: add getter/setter for orographic variables 

### DIFF
--- a/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
+++ b/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
@@ -464,6 +464,14 @@
         "dims": ["z_soil", "y", "x"]
     },
     {
+        "name": "standard_deviation_of_subgrid_orography",
+        "fortran_name": "hprime",
+        "units": "m",
+        "description": "orographic metrics",
+        "container": "Sfcprop",
+        "dims": ["z", "y", "x"]
+    },
+    {
         "name": "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",
         "fortran_name": "adjsfcdlw_override",
         "units": "W/m^2",

--- a/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
+++ b/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
@@ -464,12 +464,12 @@
         "dims": ["z_soil", "y", "x"]
     },
     {
-        "name": "standard_deviation_of_subgrid_orography",
+        "name": "orographic_variables",
         "fortran_name": "hprime",
         "units": "m",
         "description": "orographic metrics",
         "container": "Sfcprop",
-        "dims": ["nmtvr", "y", "x"]
+        "dims": ["orographic_variable", "y", "x"]
     },
     {
         "name": "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",

--- a/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
+++ b/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
@@ -469,7 +469,7 @@
         "units": "m",
         "description": "orographic metrics",
         "container": "Sfcprop",
-        "dims": ["z", "y", "x"]
+        "dims": ["nmtvr", "y", "x"]
     },
     {
         "name": "override_for_time_adjusted_total_sky_downward_longwave_flux_at_surface",

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -49,6 +49,7 @@ cdef extern:
     void get_tracer_name(int *tracer_index, char *tracer_name_out, char *tracer_long_name_out, char *tracer_units_out)
     void get_num_cpld_calls(int *num_cpld_calls_out)
     void get_nz_soil_subroutine(int *nz_soil)
+    void get_n_topographic_variables(int *n_topo_variables)
 {% for item in physics_2d_properties %}
     void get_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_out)
     void set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_in)
@@ -62,9 +63,10 @@ cdef extern:
 {% endfor %}
 
 cdef get_quantity_factory():
-    cdef int nx, ny, nz, nz_soil
+    cdef int nx, ny, nz, nz_soil, n_topo_variables
     get_centered_grid_dimensions(&nx, &ny, &nz)
     get_nz_soil_subroutine(&nz_soil)
+    get_n_topo_variables_subroutine(&n_topo_variables)
     sizer = pace.util.SubtileGridSizer(
         nx,
         ny,
@@ -72,6 +74,7 @@ cdef get_quantity_factory():
         n_halo=pace.util.N_HALO_DEFAULT,
         extra_dim_lengths={
             pace.util.Z_SOIL_DIM: nz_soil,
+            pace.util.N_TOPO_DIM:n_topo_variables,
         },
     )
     return pace.util.QuantityFactory(sizer, np)

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -66,7 +66,7 @@ cdef get_quantity_factory():
     cdef int nx, ny, nz, nz_soil, n_topo_variables
     get_centered_grid_dimensions(&nx, &ny, &nz)
     get_nz_soil_subroutine(&nz_soil)
-    get_n_topo_variables_subroutine(&n_topo_variables)
+    get_n_orographic_variables(&n_topo_variables)
     sizer = pace.util.SubtileGridSizer(
         nx,
         ny,
@@ -74,7 +74,7 @@ cdef get_quantity_factory():
         n_halo=pace.util.N_HALO_DEFAULT,
         extra_dim_lengths={
             pace.util.Z_SOIL_DIM: nz_soil,
-            pace.util.N_TOPO_DIM:n_topo_variables,
+            orographic_variable: n_topo_variables,
         },
     )
     return pace.util.QuantityFactory(sizer, np)

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -74,7 +74,7 @@ cdef get_quantity_factory():
         n_halo=pace.util.N_HALO_DEFAULT,
         extra_dim_lengths={
             pace.util.Z_SOIL_DIM: nz_soil,
-            orographic_variable: n_topo_variables,
+            "orographic_variable": n_topo_variables,
         },
     )
     return pace.util.QuantityFactory(sizer, np)

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -49,7 +49,7 @@ cdef extern:
     void get_tracer_name(int *tracer_index, char *tracer_name_out, char *tracer_long_name_out, char *tracer_units_out)
     void get_num_cpld_calls(int *num_cpld_calls_out)
     void get_nz_soil_subroutine(int *nz_soil)
-    void get_n_topographic_variables(int *n_topo_variables)
+    void get_n_orographic_variables(int *n_topo_variables)
 {% for item in physics_2d_properties %}
     void get_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_out)
     void set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_in)

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -49,7 +49,7 @@ cdef extern:
     void get_tracer_name(int *tracer_index, char *tracer_name_out, char *tracer_long_name_out, char *tracer_units_out)
     void get_num_cpld_calls(int *num_cpld_calls_out)
     void get_nz_soil_subroutine(int *nz_soil)
-    void get_n_orographic_variables(int *n_topo_variables)
+    void get_n_orographic(int *n_topo_variables)
 {% for item in physics_2d_properties %}
     void get_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_out)
     void set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}(REAL_t *{{ item.fortran_name }}_in)
@@ -66,7 +66,7 @@ cdef get_quantity_factory():
     cdef int nx, ny, nz, nz_soil, n_topo_variables
     get_centered_grid_dimensions(&nx, &ny, &nz)
     get_nz_soil_subroutine(&nz_soil)
-    get_n_orographic_variables(&n_topo_variables)
+    get_n_orographic(&n_topo_variables)
     sizer = pace.util.SubtileGridSizer(
         nx,
         ny,

--- a/FV3/wrapper/templates/physics_data.F90
+++ b/FV3/wrapper/templates/physics_data.F90
@@ -16,6 +16,11 @@ contains
         nz_soil = IPD_Control%lsoil
     end subroutine get_nz_soil_subroutine
 
+    subroutine get_n_topographic_variables(n_topo_variables) bind(c)
+        integer(c_int), intent(out) :: n_topo_variables
+        n_topo_variables = IPD_Control%nmtvr
+    end subroutine get_n_topo_variables_subroutine
+
 {% for item in physics_2d_properties %}
     subroutine set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}({{ item.fortran_name }}) bind(c)
         real(c_double), intent(in), dimension(i_start():i_end(), j_start():j_end()) :: {{ item.fortran_name }}

--- a/FV3/wrapper/templates/physics_data.F90
+++ b/FV3/wrapper/templates/physics_data.F90
@@ -16,10 +16,10 @@ contains
         nz_soil = IPD_Control%lsoil
     end subroutine get_nz_soil_subroutine
 
-    subroutine get_n_orographic_variables(n_topo_variables) bind(c)
+    subroutine get_n_orographic(n_topo_variables) bind(c)
         integer(c_int), intent(out) :: n_topo_variables
         n_topo_variables = IPD_Control%nmtvr
-    end subroutine get_n_orographic_variables
+    end subroutine get_n_orographic
 
 {% for item in physics_2d_properties %}
     subroutine set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}({{ item.fortran_name }}) bind(c)

--- a/FV3/wrapper/templates/physics_data.F90
+++ b/FV3/wrapper/templates/physics_data.F90
@@ -16,10 +16,10 @@ contains
         nz_soil = IPD_Control%lsoil
     end subroutine get_nz_soil_subroutine
 
-    subroutine get_n_topographic_variables(n_topo_variables) bind(c)
+    subroutine get_n_orographic_variables(n_topo_variables) bind(c)
         integer(c_int), intent(out) :: n_topo_variables
         n_topo_variables = IPD_Control%nmtvr
-    end subroutine get_n_topo_variables_subroutine
+    end subroutine get_n_orographic_variables
 
 {% for item in physics_2d_properties %}
     subroutine set_{{ item.fortran_name }}{% if "fortran_subname" in item %}_{{ item.fortran_subname }}{% endif %}({{ item.fortran_name }}) bind(c)


### PR DESCRIPTION
The goal of this PR is to add a subroutine to physics_data.F90 to get orographic variables ( hprime in fortran) outputs. 

- get_n_orographic_variables is added to physics_data.F90 
- get_quantity_factory() was modified in the  _wrapper.pyx to output a hard-coded orographic variables 
- the physics_properties.json  file was modify to output this new variable. 

The 11 tests with CI located in FV3/wrapper/tests/pytest pass successfully. 
