### PR TITLE
Harmonize definition of NCEPlibs and ESMF environment variables in configure files

### DIFF
--- a/FV3/conf/configure.fv3.gnu_docker
+++ b/FV3/conf/configure.fv3.gnu_docker
@@ -22,9 +22,12 @@ HYDRO = N
 32BIT = N
 
 NEMSIOINC = -I$(NEMSIO_INC)
+NCEPLIBS_DIR ?= /opt/NCEPlibs
+NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
 
-NCEPLIBS_DIR ?= /opt/NCEPlibs/lib
-NCEPLIBS = -L$(NCEPLIBS_DIR) -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
+include $(ESMFMKFILE)
+ESMF_INC = $(ESMF_F90COMPILEPATHS)
+ESMF_LIB = $(ESMF_F90ESMFLINKPATHS) $(ESMF_F90ESMFLINKLIBS)
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -88,7 +91,7 @@ CFLAGS_OPENMP = -fopenmp
 CFLAGS_DEBUG = -O0 -g 
 CFLAGS_GCOV = --coverage
 
-LDFLAGS := -L${ESMF_DIR}/lib -L${FMS_DIR}/libFMS/.libs/
+LDFLAGS := $(ESMF_LIB) -L${FMS_DIR}/libFMS/.libs/
 LDFLAGS_OPENMP := -fopenmp
 LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
 LDFLAGS_GCOV = --coverage
@@ -138,6 +141,6 @@ FFLAGS += -I/usr/local/include -DENABLE_CALLPYFORT
 LDFLAGS += -L/usr/local/lib -lcallpy 
 endif
 
-LIBS += -lFMS -L/usr/local/esmf/lib -lesmf -lnetcdff -lnetcdf -llapack -lblas -lc -lrt
+LIBS += -lFMS -lesmf -lnetcdff -lnetcdf -llapack -lblas -lc -lrt
 
 LDFLAGS += $(LIBS)

--- a/FV3/conf/configure.fv3.gnu_docker_serialize
+++ b/FV3/conf/configure.fv3.gnu_docker_serialize
@@ -22,9 +22,12 @@ HYDRO = N
 32BIT = N
 
 NEMSIOINC = -I$(NEMSIO_INC)
+NCEPLIBS_DIR ?= /opt/NCEPlibs
+NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
 
-NCEPLIBS_DIR ?= /opt/NCEPlibs/lib
-NCEPLIBS = -L$(NCEPLIBS_DIR) -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
+include $(ESMFMKFILE)
+ESMF_INC = $(ESMF_F90COMPILEPATHS)
+ESMF_LIB = $(ESMF_F90ESMFLINKPATHS) $(ESMF_F90ESMFLINKLIBS)
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #
@@ -88,7 +91,7 @@ CFLAGS_OPENMP = -fopenmp
 CFLAGS_DEBUG = -O0 -g 
 CFLAGS_GCOV = --coverage
 
-LDFLAGS := -L${ESMF_DIR}/lib/libO3/Linux.gfortran.64.mpiuni.default/ -L${FMS_DIR}/libFMS/.libs/
+LDFLAGS := $(ESMF_LIB) -L${FMS_DIR}/libFMS/.libs/
 LDFLAGS +=  -L$(SERIALBOX_DIR)/lib  -lSerialboxFortran -lSerialboxC -lSerialboxCore -L/lib/x86_64-linux-gnu -lpthread -lstdc++ -lstdc++fs
 LDFLAGS_OPENMP := -fopenmp
 LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
@@ -130,6 +133,6 @@ FFLAGS += $(FFLAGS_VERBOSE)
 LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
-LIBS += -lFMS -L/usr/local/esmf/lib -lesmf -lnetcdff -lnetcdf -llapack -lblas -lc -lrt
+LIBS += -lFMS -lesmf -lnetcdff -lnetcdf -llapack -lblas -lc -lrt
 
 LDFLAGS += $(LIBS)

--- a/FV3/conf/configure.fv3.nix
+++ b/FV3/conf/configure.fv3.nix
@@ -26,8 +26,8 @@ HYDRO = N
 
 NEMSIOINC = -I$(NEMSIO_INC)
 
-NCEPLIBS_DIR ?= /opt/NCEPlibs/lib
-NCEPLIBS = -L$(NCEPLIBS_DIR) -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
+NCEPLIBS_DIR ?= /opt/NCEPlibs
+NCEPLIBS = -L$(NCEPLIBS_DIR)/lib -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
 
 ##############################################
 # Need to use at least GNU Make version 3.81 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -205,6 +205,8 @@ FROM fv3gfs-environment AS fv3gfs-environment-standard
 ##---------------------------------------------------------------------------------
 FROM fv3gfs-environment-${fv3_build_env_tag} AS fv3gfs-build
 
+ENV ESMFMKFILE=/usr/local/esmf/lib/esmf.mk
+
 ENV SERIALBOX_DIR=/serialbox \
     SERIALBOX_OUTDIR=/FV3 \
     FMS_DIR=/FMS \


### PR DESCRIPTION
For other platforms `NCEPLIBS_DIR` refers to the base NCEPlibs install directory rather than `NCEPlibs/lib`.  In addition, for ESMF-related environment variables it [is recommended](https://earthsystemmodeling.org/docs/release/ESMF_5_2_0p1/ESMF_usrdoc/node9.html#SECTION00098000000000000000) to include the `ESMFMKFILE` and build up from the variables defined in there.

Making sure these variables have a consistent meaning across configure files will make it easier write general scripts to build the model on multiple platforms.

(This is split out of #325 to make for a more atomic change)