### PR TITLE
Enable overriding compiler settings with environment variables

### DIFF
--- a/FV3/conf/configure.fv3.gaea
+++ b/FV3/conf/configure.fv3.gaea
@@ -1,10 +1,10 @@
 ############
 # commands #
 ############
-FC = ftn
-CC = cc
-CXX = CC
-LD = ftn
+FC ?= ftn
+CC ?= cc
+CXX ?= CC
+LD ?= ftn
 
 #########
 # flags #

--- a/FV3/conf/configure.fv3.gaea
+++ b/FV3/conf/configure.fv3.gaea
@@ -1,10 +1,22 @@
 ############
 # commands #
 ############
-FC ?= ftn
-CC ?= cc
-CXX ?= CC
-LD ?= ftn
+
+# Note that FC, CC, and CXX are implicitly defined variables in makefiles. Therefore 
+# special handling is required to give them default values.
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+# https://stackoverflow.com/questions/18007326/how-to-change-default-values-of-variables-like-cc-in-makefile
+# https://www.gnu.org/software/make/manual/html_node/Origin-Function.html#Origin-Function
+ifeq ($(origin FC),default)
+FC = ftn
+endif
+ifeq ($(origin CC),default)
+CC = cc
+endif
+ifeq ($(origin CXX),default)
+CXX = CC
+endif
+LD = ftn
 
 #########
 # flags #

--- a/FV3/conf/configure.fv3.gnu_docker
+++ b/FV3/conf/configure.fv3.gnu_docker
@@ -2,10 +2,10 @@
 ############
 # commands #
 ############
-FC = mpif90
-CC = mpicc
-CXX = g++
-LD = mpif90
+FC ?= mpif90
+CC ?= mpicc
+CXX ?= g++
+LD ?= mpif90
 
 NETCDF_DIR = /usr
 

--- a/FV3/conf/configure.fv3.gnu_docker
+++ b/FV3/conf/configure.fv3.gnu_docker
@@ -2,10 +2,22 @@
 ############
 # commands #
 ############
-FC ?= mpif90
-CC ?= mpicc
-CXX ?= g++
-LD ?= mpif90
+
+# Note that FC, CC, and CXX are implicitly defined variables in makefiles. Therefore 
+# special handling is required to give them default values.
+# https://stackoverflow.com/questions/18007326/how-to-change-default-values-of-variables-like-cc-in-makefile
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+# https://www.gnu.org/software/make/manual/html_node/Origin-Function.html#Origin-Function
+ifeq ($(origin FC),default)
+FC = mpif90
+endif
+ifeq ($(origin CC),default)
+CC = mpicc
+endif
+ifeq ($(origin CXX),default)
+CXX = g++
+endif
+LD = mpif90
 
 NETCDF_DIR = /usr
 


### PR DESCRIPTION
This PR addresses #330 by enabling us to override the compilers defined in existing configure files using environment variables.