### PR TITLE
Wrapper: Model initialization time getter

### DIFF
--- a/FV3/wrapper/lib/coupler_lib.F90
+++ b/FV3/wrapper/lib/coupler_lib.F90
@@ -242,6 +242,13 @@ contains
         call get_date(Atm%Time, year, month, day, hour, minute, second)
         fms_calendar_type = calendar_type
     end subroutine get_time
+    
+    subroutine get_initialization_time(year, month, day, hour, minute, second, fms_calendar_type) & 
+        bind(c, name='get_initialization_time_subroutine')
+        integer, intent(out) :: year, month, day, hour, minute, second, fms_calendar_type
+        call get_date(Atm%Time_init, year, month, day, hour, minute, second)
+        fms_calendar_type = calendar_type
+    end subroutine get_initialization_time
 
     subroutine get_physics_timestep_subroutine(physics_timestep) bind(c)
         integer, intent(out) :: physics_timestep

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -31,6 +31,9 @@ cdef extern:
     void save_intermediate_restart_subroutine()
     void initialize_time_subroutine(int *year, int *month, int *day, int *hour, int *minute, int *second)
     void get_time_subroutine(int *year, int *month, int *day, int *hour, int *minute, int *second, int *fms_calendar_type)
+    void get_initialization_time_subroutine(
+        int *year, int *month, int *day, int *hour, int *minute, int *second, int *fms_calendar_type
+    )
     void get_physics_timestep_subroutine(int *physics_timestep)
     void get_centered_grid_dimensions(int *nx, int *ny, int *nz)
     void get_n_ghost_cells_subroutine(int *n_ghost)
@@ -121,11 +124,20 @@ def set_time(time):
     initialize_time_subroutine(&year, &month, &day, &hour, &minute, &second)
 
 
-def get_time():
+def get_time(which=None):
     """Returns a cftime.datetime corresponding to the current model time.
     """
     cdef int year, month, day, hour, minute, second, fms_calendar_type
-    get_time_subroutine(&year, &month, &day, &hour, &minute, &second, &fms_calendar_type)
+    if which is None:
+        get_time_subroutine(
+            &year, &month, &day, &hour, &minute, &second, &fms_calendar_type
+        )
+    elif which == 'initialization_time':
+        get_initialization_time_subroutine(
+            &year, &month, &day, &hour, &minute, &second, &fms_calendar_type
+        )
+    else:
+        raise ValueError(f'Invalid get_time option {which}.')
     return pace.util.FMS_TO_CFTIME_TYPE[fms_calendar_type](year, month, day, hour, minute, second)
 
 
@@ -280,6 +292,9 @@ def get_state(names, dict state=None, allocator=None):
 
     if 'time' in input_names_set:
         state['time'] = get_time()
+        
+    if 'initialization_time' in input_names_set:
+        state['initialization_time'] = get_time(which='initialization_time')
 
 {% for item in physics_2d_properties %}
     {% if item.name in overriding_fluxes %}

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -124,11 +124,16 @@ def set_time(time):
     initialize_time_subroutine(&year, &month, &day, &hour, &minute, &second)
 
 
-def get_time(which=None):
-    """Returns a cftime.datetime corresponding to the current model time.
+def get_time(which='model_time'):
+    """Returns a cftime.datetime corresponding to either the current model time
+    or the model initialization time.
+    
+    Arguments:
+        which (str): If omitted or "model_time", returns the current model time.
+            If "initialization_time", returns the GFS physics' initialization time.
     """
     cdef int year, month, day, hour, minute, second, fms_calendar_type
-    if which is None:
+    if which == 'model_time':
         get_time_subroutine(
             &year, &month, &day, &hour, &minute, &second, &fms_calendar_type
         )
@@ -137,7 +142,7 @@ def get_time(which=None):
             &year, &month, &day, &hour, &minute, &second, &fms_calendar_type
         )
     else:
-        raise ValueError(f'Invalid get_time option {which}.')
+        raise ValueError(f'Invalid `get_time` option `which`: "{which}".')
     return pace.util.FMS_TO_CFTIME_TYPE[fms_calendar_type](year, month, day, hour, minute, second)
 
 

--- a/FV3/wrapper/tests/from_restarts_config.yml
+++ b/FV3/wrapper/tests/from_restarts_config.yml
@@ -1,0 +1,297 @@
+data_table: default
+diag_table: default
+experiment_name: default_experiment
+forcing: gs://vcm-fv3config/data/base_forcing/v1.1
+initial_conditions: gs://vcm-fv3config/data/initial_conditions/c12_restart_initial_conditions/v1.0
+namelist:
+  amip_interp_nml:
+    data_set: reynolds_oi
+    date_out_of_range: climo
+    interp_oi_sst: true
+    no_anom_sst: false
+    use_ncep_ice: false
+    use_ncep_sst: true
+  atmos_model_nml:
+    blocksize: 24
+    chksum_debug: false
+    dycore_only: false
+    fdiag: 0.0
+    fhmax: 1024.0
+    fhmaxhf: -1.0
+    fhout: 0.25
+    fhouthf: 0.0
+  cires_ugwp_nml:
+    knob_ugwp_azdir:
+    - 2
+    - 4
+    - 4
+    - 4
+    knob_ugwp_doaxyz: 1
+    knob_ugwp_doheat: 1
+    knob_ugwp_dokdis: 0
+    knob_ugwp_effac:
+    - 1
+    - 1
+    - 1
+    - 1
+    knob_ugwp_ndx4lh: 4
+    knob_ugwp_solver: 2
+    knob_ugwp_source:
+    - 1
+    - 1
+    - 1
+    - 0
+    knob_ugwp_stoch:
+    - 0
+    - 0
+    - 0
+    - 0
+    knob_ugwp_version: 0
+    knob_ugwp_wvspec:
+    - 1
+    - 32
+    - 32
+    - 32
+    launch_level: 55
+  coupler_nml:
+    atmos_nthreads: 1
+    calendar: julian
+    current_date:
+    - 2016
+    - 8
+    - 1
+    - 0
+    - 0
+    - 0
+    days: 0
+    dt_atmos: 900
+    dt_ocean: 900
+    force_date_from_namelist: false
+    hours: 0
+    memuse_verbose: true
+    minutes: 30
+    months: 0
+    ncores_per_node: 32
+    seconds: 0
+    use_hyper_thread: true
+  diag_manager_nml:
+    prepend_date: false
+  external_ic_nml:
+    checker_tr: false
+    filtered_terrain: true
+    gfs_dwinds: true
+    levp: 64
+    nt_checker: 0
+  fms_io_nml:
+    checksum_required: false
+    max_files_r: 100
+    max_files_w: 100
+  fms_nml:
+    clock_grain: ROUTINE
+    domains_stack_size: 3000000
+    print_memory_usage: false
+  fv_core_nml:
+    a_imp: 1.0
+    adjust_dry_mass: false
+    beta: 0.0
+    consv_am: false
+    consv_te: 1.0
+    d2_bg: 0.0
+    d2_bg_k1: 0.16
+    d2_bg_k2: 0.02
+    d4_bg: 0.15
+    d_con: 1.0
+    d_ext: 0.0
+    dddmp: 0.2
+    delt_max: 0.002
+    dnats: 1
+    do_sat_adj: true
+    do_vort_damp: true
+    dwind_2d: false
+    external_ic: false
+    fill: true
+    fv_debug: false
+    fv_sg_adj: 900
+    gfs_phil: false
+    hord_dp: 6
+    hord_mt: 6
+    hord_tm: 6
+    hord_tr: 8
+    hord_vt: 6
+    hydrostatic: false
+    io_layout:
+    - 1
+    - 1
+    k_split: 1
+    ke_bg: 0.0
+    kord_mt: 10
+    kord_tm: -10
+    kord_tr: 10
+    kord_wz: 10
+    layout:
+    - 1
+    - 1
+    make_nh: false
+    mountain: true
+    n_split: 6
+    n_sponge: 4
+    na_init: 0
+    ncep_ic: false
+    nggps_ic: false
+    no_dycore: false
+    nord: 2
+    npx: 13
+    npy: 13
+    npz: 63
+    ntiles: 6
+    nudge: false
+    nudge_qv: true
+    nwat: 6
+    p_fac: 0.1
+    phys_hydrostatic: false
+    print_freq: 3
+    range_warn: true
+    reset_eta: false
+    rf_cutoff: 800.0
+    rf_fast: false
+    tau: 5.0
+    use_hydro_pressure: false
+    vtdm4: 0.06
+    warm_start: true
+    z_tracer: true
+  fv_grid_nml: {}
+  gfdl_cloud_microphysics_nml:
+    c_cracw: 0.8
+    c_paut: 0.5
+    c_pgacs: 0.01
+    c_psaci: 0.05
+    ccn_l: 300.0
+    ccn_o: 100.0
+    const_vg: false
+    const_vi: false
+    const_vr: false
+    const_vs: false
+    de_ice: false
+    do_qa: true
+    do_sedi_heat: false
+    dw_land: 0.16
+    dw_ocean: 0.1
+    fast_sat_adj: true
+    fix_negative: true
+    icloud_f: 1
+    mono_prof: true
+    mp_time: 450.0
+    prog_ccn: false
+    qi0_crt: 8.0e-05
+    qi_lim: 1.0
+    ql_gen: 0.001
+    ql_mlt: 0.001
+    qs0_crt: 0.001
+    rad_graupel: true
+    rad_rain: true
+    rad_snow: true
+    rh_inc: 0.3
+    rh_inr: 0.3
+    rh_ins: 0.3
+    rthresh: 1.0e-05
+    sedi_transport: false
+    tau_g2v: 900.0
+    tau_i2s: 1000.0
+    tau_l2v:
+    - 225.0
+    tau_v2l: 150.0
+    use_ccn: true
+    use_ppm: false
+    vg_max: 12.0
+    vi_max: 1.0
+    vr_max: 12.0
+    vs_max: 2.0
+    z_slope_ice: true
+    z_slope_liq: true
+  gfs_physics_nml:
+    cal_pre: false
+    cdmbgwd:
+    - 3.5
+    - 0.25
+    cnvcld: false
+    cnvgwd: true
+    debug: false
+    dspheat: true
+    fhcyc: 24.0
+    fhlwr: 3600.0
+    fhswr: 3600.0
+    fhzero: 0.25
+    hybedmf: true
+    iaer: 111
+    ialb: 1
+    ico2: 2
+    iems: 1
+    imfdeepcnv: 2
+    imfshalcnv: 2
+    imp_physics: 11
+    isol: 2
+    isot: 1
+    isubc_lw: 2
+    isubc_sw: 2
+    ivegsrc: 1
+    ldiag3d: true
+    lwhtr: true
+    ncld: 5
+    nst_anl: true
+    pdfcld: false
+    pre_rad: false
+    prslrd0: 0.0
+    random_clds: false
+    redrag: true
+    shal_cnv: true
+    swhtr: true
+    trans_trac: true
+    use_ufo: true
+  interpolator_nml:
+    interp_method: conserve_great_circle
+  nam_stochy:
+    lat_s: 96
+    lon_s: 192
+    ntrunc: 94
+  namsfc:
+    fabsl: 99999
+    faisl: 99999
+    faiss: 99999
+    fnabsc: grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb
+    fnacna: ''
+    fnaisc: grb/CFSR.SEAICE.1982.2012.monthly.clim.grb
+    fnalbc: grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb
+    fnalbc2: grb/global_albedo4.1x1.grb
+    fnglac: grb/global_glacier.2x2.grb
+    fnmskh: grb/seaice_newland.grb
+    fnmxic: grb/global_maxice.2x2.grb
+    fnslpc: grb/global_slope.1x1.grb
+    fnsmcc: grb/global_soilmgldas.t1534.3072.1536.grb
+    fnsnoa: ''
+    fnsnoc: grb/global_snoclim.1.875.grb
+    fnsotc: grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb
+    fntg3c: grb/global_tg3clim.2.6x1.5.grb
+    fntsfa: ''
+    fntsfc: grb/RTGSST.1982.2012.monthly.clim.grb
+    fnvegc: grb/global_vegfrac.0.144.decpercent.grb
+    fnvetc: grb/global_vegtype.igbp.t1534.3072.1536.rg.grb
+    fnvmnc: grb/global_shdmin.0.144x0.144.grb
+    fnvmxc: grb/global_shdmax.0.144x0.144.grb
+    fnzorc: igbp
+    fsicl: 99999
+    fsics: 99999
+    fslpl: 99999
+    fsmcl:
+    - 99999
+    - 99999
+    - 99999
+    fsnol: 99999
+    fsnos: 99999
+    fsotl: 99999
+    ftsfl: 99999
+    ftsfs: 90
+    fvetl: 99999
+    fvmnl: 99999
+    fvmxl: 99999
+    ldebug: false
+orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0

--- a/FV3/wrapper/tests/test_all_mpi_requiring.py
+++ b/FV3/wrapper/tests/test_all_mpi_requiring.py
@@ -36,6 +36,9 @@ class UsingMPITests(unittest.TestCase):
 
     def test_get_time_calendar_noleap(self):
         run_unittest_script("test_get_time.py", "noleap")
+    
+    def test_get_initialization_time(self):
+        run_unittest_script("test_get_initialization_time.py")
 
     def test_flags(self):
         run_unittest_script("test_flags.py")

--- a/FV3/wrapper/tests/test_get_initialization_time.py
+++ b/FV3/wrapper/tests/test_get_initialization_time.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+from mpi4py import MPI
+import cftime
+import fv3gfs.wrapper
+from util import get_from_restarts_config, main
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class GetInitializationTimeTests(unittest.TestCase):
+
+    # these are the values in the restart file coupler.res used to initialize
+    RUN_INITIALIZATION_TIME = cftime.DatetimeJulian(2016, 8, 1, 0, 0, 0, 0)
+    SEGMENT_START_TIME = cftime.DatetimeJulian(2016, 8, 1, 0, 30, 0, 0)
+
+    def __init__(self, *args, **kwargs):
+        super(GetInitializationTimeTests, self).__init__(*args, **kwargs)
+        self.mpi_comm = MPI.COMM_WORLD
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        self.mpi_comm.barrier()
+
+    def test_get_initialization_time(self):
+        initialization_time = (
+            fv3gfs.wrapper.get_state(names=["initialization_time"])
+            ["initialization_time"]
+        )
+        current_time = fv3gfs.wrapper.get_state(names=["time"])["time"]
+        assert initialization_time == self.RUN_INITIALIZATION_TIME
+        assert current_time == self.SEGMENT_START_TIME
+        
+        
+if __name__ == "__main__":
+    config = get_from_restarts_config()
+    main(test_dir, config)

--- a/FV3/wrapper/tests/util.py
+++ b/FV3/wrapper/tests/util.py
@@ -106,7 +106,12 @@ def main(test_dir, config):
 def get_default_config():
     with open(os.path.join(base_dir, "default_config.yml"), "r") as f:
         return yaml.safe_load(f)
-
+    
+    
+def get_from_restarts_config():
+    with open(os.path.join(base_dir, "from_restarts_config.yml"), "r") as f:
+        return yaml.safe_load(f)
+    
 
 def get_current_config():
     with open("fv3config.yml") as f:


### PR DESCRIPTION
Adds a getter for the model "initialization time" to the Fortran wrapper. Note that initialization time has a special meaning to the GFS physics, which is the beginning time of an initial run (of potentially multiple segments via restarting), i.e., not necessarily the time at which the wrapper is initialized. This information is necessary for porting some aspects of the GFS physics (see #https://github.com/ai2cm/fv3config/issues/147 for some examples).