### PR TITLE
Implement hybrid coarse-graining for restart files in FV3GFS

### DIFF
--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -9,7 +9,8 @@ module coarse_grained_diagnostics_mod
   use mpp_domains_mod, only: domain2d, EAST, NORTH
   use mpp_mod, only: FATAL, mpp_error
   use coarse_graining_mod, only: block_sum, get_fine_array_bounds, get_coarse_array_bounds, MODEL_LEVEL, &
-                                 weighted_block_average, PRESSURE_LEVEL, vertically_remap_field, &
+                                 weighted_block_average, PRESSURE_LEVEL, HYBRID_MASS_WEIGHTED, HYBRID_AREA_WEIGHTED, &
+                                 vertically_remap_field, &
                                  vertical_remapping_requirements, mask_area_weights, &
                                  block_edge_sum_x, block_edge_sum_y, eddy_covariance_2d_weights, eddy_covariance_3d_weights
   use time_manager_mod, only: time_type

--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -12,10 +12,11 @@ module coarse_graining_mod
   public :: block_sum, compute_mass_weights, get_fine_array_bounds, &
        get_coarse_array_bounds, coarse_graining_init, weighted_block_average, &
        weighted_block_edge_average_x, weighted_block_edge_average_y, MODEL_LEVEL, &
-       block_upsample, mask_area_weights, PRESSURE_LEVEL, vertical_remapping_requirements, &
-       vertically_remap_field, block_mode, block_min, block_max, &
+       block_upsample, mask_area_weights, PRESSURE_LEVEL, HYBRID_MASS_WEIGHTED, HYBRID_AREA_WEIGHTED,&
+       vertical_remapping_requirements, vertically_remap_field, block_mode, block_min, block_max, &
        remap_edges_along_x, remap_edges_along_y, block_edge_sum_x, block_edge_sum_y, &
-       eddy_covariance_2d_weights, eddy_covariance_3d_weights
+       eddy_covariance_2d_weights, eddy_covariance_3d_weights, compute_blending_factor_agrid, &
+       compute_blending_factor_dgrid_u, compute_blending_factor_dgrid_v
 
   interface block_sum
      module procedure block_sum_2d
@@ -60,6 +61,7 @@ module coarse_graining_mod
 
   interface block_min
      module procedure masked_block_min_2d
+     module procedure block_min_2d
   end interface block_min
 
   interface block_max
@@ -80,6 +82,9 @@ module coarse_graining_mod
   integer :: is_coarse, ie_coarse, js_coarse, je_coarse
   character(len=11) :: MODEL_LEVEL = 'model_level'
   character(len=14) :: PRESSURE_LEVEL = 'pressure_level'
+  character(len=20) :: HYBRID_MASS_WEIGHTED = 'hybrid_mass_weighted'
+  character(len=20) :: HYBRID_AREA_WEIGHTED = 'hybrid_area_weighted'
+  real :: sigma_blend = 0.9  ! Constant defining sigma level at which we switch to pressure-level coarsening in the hybrid method.
 
   ! Namelist parameters initialized with default values
   integer :: coarsening_factor = 8
@@ -160,7 +165,7 @@ contains
 
     character(len=256) :: error_message
 
-    if (trim(strategy) .ne. MODEL_LEVEL .and. trim(strategy) .ne. PRESSURE_LEVEL) then
+    if (trim(strategy) .ne. MODEL_LEVEL .and. trim(strategy) .ne. PRESSURE_LEVEL .and. trim(strategy) .ne. HYBRID_MASS_WEIGHTED .and. trim(strategy) .ne. HYBRID_AREA_WEIGHTED) then
        write(error_message, *) 'Invalid coarse graining strategy provided.'
        call mpp_error(FATAL, error_message)
     endif
@@ -649,6 +654,22 @@ contains
     enddo
    end subroutine masked_block_min_2d
 
+   subroutine block_min_2d(fine, coarse)
+      real, intent(in) :: fine(is:ie,js:je)
+      real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse)
+  
+      integer :: i, j, i_coarse, j_coarse, offset
+  
+      offset = coarsening_factor - 1
+      do i = is, ie, coarsening_factor
+         i_coarse = (i - 1) / coarsening_factor + 1
+         do j = js, je, coarsening_factor
+            j_coarse = (j - 1) / coarsening_factor + 1
+            coarse(i_coarse, j_coarse) = minval(fine(i:i+offset,j:j+offset))
+         enddo
+      enddo
+     end subroutine block_min_2d
+
    subroutine masked_block_max_2d(fine, mask, coarse)
     real, intent(in) :: fine(is:ie,js:je)
     logical, intent(in) :: mask(is:ie,js:je)
@@ -665,6 +686,36 @@ contains
        enddo
     enddo
    end subroutine masked_block_max_2d
+
+   subroutine block_edge_min_x(fine, coarse)
+      real, intent(in) :: fine(is:ie,js_coarse:je_coarse+1)
+      real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse+1)
+  
+      integer :: i, j_coarse, i_coarse, offset
+  
+      offset = coarsening_factor - 1
+      do i = is, ie, coarsening_factor
+         i_coarse = (i - 1) / coarsening_factor + 1
+         do j_coarse = js_coarse, je_coarse+1
+            coarse(i_coarse, j_coarse) = minval(fine(i:i+offset,j_coarse))
+         enddo
+      enddo
+   end subroutine block_edge_min_x
+
+   subroutine block_edge_min_y(fine, coarse)
+      real, intent(in) :: fine(is_coarse:ie_coarse+1,js:je)
+      real, intent(out) :: coarse(is_coarse:ie_coarse,js_coarse:je_coarse+1)
+  
+      integer :: i_coarse, j, j_coarse, offset
+  
+      offset = coarsening_factor - 1
+      do i_coarse = is_coarse, ie_coarse+1
+         do j = js, je, coarsening_factor
+            j_coarse = (j - 1) / coarsening_factor + 1
+            coarse(i_coarse, j_coarse) = minval(fine(i_coarse,j:j+offset))
+         enddo
+      enddo
+   end subroutine block_edge_min_y
 
    ! A naive routine for interpolating a field from the A-grid to the y-boundary
    ! of the D-grid; this is a specialized function that automatically
@@ -1065,4 +1116,112 @@ contains
    call anomaly_3d_weights_3d_array(weights, field_b, anom_b)
    call weighted_block_average(weights, anom_a * anom_b, coarse)
  end subroutine eddy_covariance_3d_weights
+
+subroutine compute_blending_factor_agrid(phalf, coarse_phalf, blending_factor)
+  real, intent(in) :: phalf(is-1:ie+1,js-1:je+1,1:npz+1)
+  real, intent(in) :: coarse_phalf(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz+1)
+  real, intent(out) :: blending_factor(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz)
+
+  real, allocatable :: blending_pressure(:,:)
+  real, allocatable :: coarse_pfull(:,:,:)
+  real, allocatable :: coarse_surface_pressure(:,:)
+
+  integer :: k
+
+  allocate(blending_pressure(is_coarse:ie_coarse,js_coarse:je_coarse))
+  allocate(coarse_pfull(is_coarse:ie_coarse,js_coarse:je_coarse,1:npz))
+  allocate(coarse_surface_pressure(is_coarse:ie_coarse,js_coarse:je_coarse))
+
+  coarse_surface_pressure = coarse_phalf(is_coarse:ie_coarse,js_coarse:je_coarse,npz+1)
+  call compute_coarse_pfull(coarse_phalf, coarse_pfull, x_pad=0, y_pad=0)
+  call block_min(phalf(is:ie,js:je,npz+1), blending_pressure)
+  blending_pressure = sigma_blend * blending_pressure
+  do k = 1, npz
+    where (coarse_pfull(:,:,k) .gt. blending_pressure)
+      blending_factor(:,:,k) = (coarse_surface_pressure - coarse_pfull(:,:,k)) / (coarse_surface_pressure - blending_pressure)
+    elsewhere
+      blending_factor(:,:,k) = 1.0
+    endwhere
+  enddo
+end subroutine compute_blending_factor_agrid
+
+subroutine compute_blending_factor_dgrid_u(phalf, dx, blending_factor)
+  real, intent(in) :: phalf(is-1:is+1,js-1:js+1,1:npz+1)
+  real, intent(in) :: dx(is:ie,js:je+1)
+  real, intent(out) :: blending_factor(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:npz)
+
+  real, allocatable :: phalf_d_grid(:,:,:)
+  real, allocatable :: coarse_phalf_d_grid(:,:,:)
+  real, allocatable :: coarse_pfull_d_grid(:,:,:)
+  real, allocatable :: blending_pressure(:,:)
+  real, allocatable :: coarse_surface_pressure(:,:)
+
+  integer :: k
+
+  allocate(phalf_d_grid(is:ie,js_coarse:je_coarse+1,1:npz+1))
+  allocate(coarse_phalf_d_grid(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:npz+1))
+  allocate(coarse_pfull_d_grid(is_coarse:ie_coarse,js_coarse:je_coarse+1,1:npz))
+  allocate(blending_pressure(is_coarse:ie_coarse,js_coarse:je_coarse+1))
+  allocate(coarse_surface_pressure(is_coarse:ie_coarse,js_coarse:je_coarse+1))
+
+  call interpolate_to_d_grid_and_downsample_along_y(phalf, phalf_d_grid, npz+1)
+  call weighted_block_edge_average_x_pre_downsampled(phalf_d_grid, dx, coarse_phalf_d_grid, npz+1)
+  call compute_coarse_pfull(coarse_phalf_d_grid, coarse_pfull_d_grid, x_pad=0, y_pad=1)
+  call block_edge_min_x(coarse_pfull_d_grid, blending_pressure)
+  coarse_surface_pressure = coarse_phalf_d_grid(is_coarse:ie_coarse,js_coarse:je_coarse+1,npz+1)
+  blending_pressure = sigma_blend * blending_pressure
+
+  do k = 1, npz
+   where (coarse_pfull_d_grid(:,:,k) .gt. blending_pressure)
+     blending_factor(:,:,k) = (coarse_surface_pressure - coarse_pfull_d_grid(:,:,k)) / (coarse_surface_pressure - blending_pressure)
+   elsewhere
+     blending_factor(:,:,k) = 1.0
+   endwhere
+ enddo
+end subroutine compute_blending_factor_dgrid_u
+
+subroutine compute_blending_factor_dgrid_v(phalf, dy, blending_factor)
+  real, intent(in) :: phalf(is-1:is+1,js-1:js+1,1:npz+1)
+  real, intent(in) :: dy(is:ie,js:je+1)
+  real, intent(out) :: blending_factor(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz)
+
+  real, allocatable :: phalf_d_grid(:,:,:)
+  real, allocatable :: coarse_phalf_d_grid(:,:,:)
+  real, allocatable :: coarse_pfull_d_grid(:,:,:)
+  real, allocatable :: blending_pressure(:,:)
+  real, allocatable :: coarse_surface_pressure(:,:)
+
+  integer :: k
+
+  allocate(phalf_d_grid(is_coarse:ie_coarse+1,js:je,1:npz+1))
+  allocate(coarse_phalf_d_grid(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz+1))
+  allocate(coarse_pfull_d_grid(is_coarse:ie_coarse+1,js_coarse:je_coarse,1:npz))
+  allocate(blending_pressure(is_coarse:ie_coarse+1,js_coarse:je_coarse))
+  allocate(coarse_surface_pressure(is_coarse:ie_coarse+1,js_coarse:je_coarse))
+
+  call interpolate_to_d_grid_and_downsample_along_x(phalf, phalf_d_grid, npz+1)
+  call weighted_block_edge_average_y_pre_downsampled(phalf_d_grid, dy, coarse_phalf_d_grid, npz+1)
+  call compute_coarse_pfull(coarse_phalf_d_grid, coarse_pfull_d_grid, x_pad=1, y_pad=0)
+  call block_edge_min_y(coarse_pfull_d_grid, blending_pressure)
+  coarse_surface_pressure = coarse_phalf_d_grid(is_coarse:ie_coarse+1,js_coarse:je_coarse,npz+1)
+  blending_pressure = sigma_blend * blending_pressure
+
+  do k = 1, npz
+   where (coarse_pfull_d_grid(:,:,k) .gt. blending_pressure)
+     blending_factor(:,:,k) = (coarse_surface_pressure - coarse_pfull_d_grid(:,:,k)) / (coarse_surface_pressure - blending_pressure)
+   elsewhere
+     blending_factor(:,:,k) = 1.0
+   endwhere
+ enddo
+end subroutine compute_blending_factor_dgrid_v
+
+subroutine compute_coarse_pfull(coarse_phalf, coarse_pfull, x_pad, y_pad)
+  integer, intent(in) :: x_pad, y_pad
+  real, intent(in) :: coarse_phalf(is_coarse:ie_coarse+x_pad,js_coarse:je_coarse+y_pad,1:npz+1)
+  real, intent(out) :: coarse_pfull(is_coarse:ie_coarse+x_pad,js_coarse:je_coarse+y_pad,1:npz)
+  
+  coarse_pfull = (coarse_phalf(:,:,1:npz) - coarse_phalf(:,:,2:npz+1)) / &
+                 (log(coarse_phalf(:,:,1:npz)) - log(coarse_phalf(:,:,2:npz+1)))
+end subroutine compute_coarse_pfull
+
 end module coarse_graining_mod


### PR DESCRIPTION
This PR implements hybrid coarse-graining for restart files in FV3GFS.  It introduces two new options, `"hybrid_mass_weighted"` and `"hybrid_area_weighted"`.  These are for hybrid pressure level / mass-weighted model level coarse-graining and pressure level / area-weighted model level coarse-graining, respectively.  

It implements the approach described by Chris in Section 7 of [this document](https://drive.google.com/file/d/1FyLTnR1C5_Ab5Tdbbuhtxm52VC-NroJG/view) to smoothly transition between model level coarse graining near the surface to pressure level coarse-graining aloft.  