### PR TITLE
Defer slow (not necessarily essential) tests to after merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - nix
       - run:
           name: Test fortran
-          command: nix-shell --run "pytest --native tests/pytest -v"
+          command: nix-shell --run "make test_native_fortran"
       - run:
           name: Test wrapper
           command: nix-shell --run "make -C FV3/wrapper test"
@@ -61,7 +61,7 @@ jobs:
       - nix
       - run:
           name: Test fortran
-          command: nix-shell --run "pytest --native tests/pytest -v -m basic"
+          command: nix-shell --run "make test_native_fortran_basic"
       - run:
           name: Test wrapper
           command: nix-shell --run "make -C FV3/wrapper test_basic"
@@ -76,7 +76,7 @@ jobs:
       - nix
       - run:
           name: Test fortran
-          command: nix-shell --run "pytest --native tests/pytest -v -m coarse"
+          command: nix-shell --run "make test_native_fortran_coarse_graining"
       - run:
           name: Test wrapper
           command: nix-shell --run "make -C FV3/wrapper test_coarse_graining"
@@ -91,7 +91,7 @@ jobs:
       - nix
       - run:
           name: Test fortran
-          command: nix-shell --run "pytest --native tests/pytest -v -m emulation"
+          command: nix-shell --run "make test_native_fortran_emulation"
       - run:
           name: Test wrapper
           command: nix-shell --run "make -C FV3/wrapper test_emulation"
@@ -106,7 +106,7 @@ jobs:
       - nix
       - run:
           name: Test fortran
-          command: nix-shell --run "pytest --native tests/pytest -v -m 'not basic and not coarse and not emulation'"
+          command: nix-shell --run "make test_native_fortran_unmarked"
   nix-wrapper:
     docker:
       - image: nixos/nix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
       - restore_cache:
           name: Restore nix build cache
           keys:
-            - nix-fv3gfs-fortran-{{ git rev-parse HEAD }}
+            - nix-fv3gfs-fortran-{{ .Environment.CIRCLE_SHA1 }}
       - run: |
           nix-env -iA cachix -f https://cachix.org/api/v1/install
           cachix use vulcanclimatemodeling
@@ -38,7 +38,7 @@ commands:
           command: nix-shell --run "make -j 4 -C FV3 wrapper_build"
       - save_cache:
           name: Save nix build cache
-          key: nix-fv3gfs-fortran-{{ git rev-parse HEAD }}
+          key: nix-fv3gfs-fortran-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - FV3/
       - run:
@@ -162,7 +162,7 @@ workflows:
       - nix-additional:
           name: "Additional native tests"
           requires:
-            - nix-basic
+            - Minimal native tests
             - hold-nix-additional
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
           command: nix-shell --run "pytest --native tests/pytest -v << parameters.fortran-pytest-args >>"
       - run:
           name: Test wrapper
-          command: nix-shell --run "make << parameters.wrapper-make-rule >>"
+          command: nix-shell --run "make -C FV3/wrapper << parameters.wrapper-make-rule >>"
 jobs:
   nix-full:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ commands:
           command: |
             git submodule init
             git submodule update
+      - restore_cache:
+          name: Restore nix build cache
+          keys:
+            - nix-fv3gfs-fortran-{{ git rev-parse HEAD }}
       - run: |
           nix-env -iA cachix -f https://cachix.org/api/v1/install
           cachix use vulcanclimatemodeling
@@ -32,6 +36,11 @@ commands:
       - run:
           name: Build wrapper
           command: nix-shell --run "make -j 4 -C FV3 wrapper_build"
+      - save_cache:
+          name: Save nix build cache
+          key: nix-fv3gfs-fortran-{{ git rev-parse HEAD }}
+          paths:
+            - FV3/
       - run:
           name: Test
           command: nix-shell --run "pytest --native tests/pytest -v << parameters.fortran-pytest-args >>"
@@ -153,6 +162,7 @@ workflows:
       - nix-additional:
           name: "Additional native tests"
           requires:
+            - nix-basic
             - hold-nix-additional
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,16 @@
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.0
-jobs:
-  nix-mac:
-    macos:
-      xcode: 11.3.0
-    environment:
-      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
-      MPIR_CVAR_OFI_SKIP_IPV6: "1"
-      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
-    steps:
-      - run: |
-          curl -L -O https://nixos.org/nix/install
-          sh install --darwin-use-unencrypted-nix-store-volume
-          rm -f install
-      - run: |
-          nix-env -i git openssh google-cloud-sdk
-          nix-env -iA cachix -f https://cachix.org/api/v1/install
-          cachix use vulcanclimatemodeling
-          echo $ENCODED_GCR_KEY | base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
-      - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule init
-            git submodule update
-      - run: |
-          nix-build -j 4 -A fms | cachix push vulcanclimatemodeling
-          nix-shell --run "cd FV3 && bash configure nix && make -j 4"
-          # additional changes to the DNS settings are needed for mac
-          # https://stackoverflow.com/questions/23112515/mpich2-gethostbyname-failed
-          echo "127.0.0.1 $HOSTNAME" | sudo tee -a /etc/hosts
-      - run:
-          name: Test
-          command: nix-shell --run "pytest --native tests/pytest"
+commands:
   nix:
-    docker:
-      - image: nixos/nix
-    environment:
-      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
-      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
-      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    description: "Install and run tests via nix"
+    parameters:
+      fortran-pytest-args:
+        type: string
+        default: ""
+      wrapper-make-rule:
+        type: string
+        default: test
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout
@@ -65,10 +34,42 @@ jobs:
           command: nix-shell --run "make -j 4 -C FV3 wrapper_build"
       - run:
           name: Test
-          command: nix-shell --run "pytest --native tests/pytest -v"
+          command: nix-shell --run "pytest --native tests/pytest -v << parameters.fortran-pytest-args >>"
       - run:
           name: Test wrapper
-          command: nix-shell --run "make test_wrapper"
+          command: nix-shell --run "make << parameters.wrapper-make-rule >>"
+jobs:
+  nix-full:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix
+  nix-basic:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix:
+          fortran-pytest-args: "-m 'not slow'"
+          wrapper-make-rule: "test_basic"
+  nix-additional:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix:
+          fortran-pytest-args: "-m 'slow'"
+          wrapper-make-rule: "test_additional"
   lint:
     docker:
       - image: circleci/python:3.9
@@ -76,7 +77,6 @@ jobs:
       - checkout
       - run: sudo pip3 install pre-commit==2.15.0
       - run: pre-commit
-
   build_default:
     machine:
       docker_layer_caching: true
@@ -139,7 +139,35 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_default
-      - nix
       - lint
-#      - nix-mac
+      - nix-basic:
+          name: "Minimal native tests"
+          filters:
+            branches:
+              ignore: master
+      - hold-nix-additional:
+          type: approval
+          filters:
+            branches:
+              ignore: master
+      - nix-additional:
+          name: "Additional native tests"
+          requires:
+            - hold-nix-additional
+          filters:
+            branches:
+              ignore: master
+      - hold-build_default:
+          type: approval
+          filters:
+            branches:
+              ignore: master
+      - build_default:
+          name: "Docker tests"
+          requires:
+            - hold-build_default
+      - nix-full:
+          name: "Full native tests"
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,7 @@ orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.0
 commands:
   nix:
-    description: "Install and run tests via nix"
-    parameters:
-      fortran-pytest-args:
-        type: string
-        default: ""
-      wrapper-make-rule:
-        type: string
-        default: test
+    description: "Build fortran and wrapper in nix environment"
     steps:
       - run: nix-env -i git openssh google-cloud-sdk
       - checkout
@@ -41,12 +34,6 @@ commands:
           key: nix-fv3gfs-fortran-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - FV3/
-      - run:
-          name: Test
-          command: nix-shell --run "pytest --native tests/pytest -v << parameters.fortran-pytest-args >>"
-      - run:
-          name: Test wrapper
-          command: nix-shell --run "make -C FV3/wrapper << parameters.wrapper-make-rule >>"
 jobs:
   nix-full:
     docker:
@@ -57,6 +44,12 @@ jobs:
       FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
       - nix
+      - run:
+          name: Test fortran
+          command: nix-shell --run "pytest --native tests/pytest -v"
+      - run:
+          name: Test wrapper
+          command: nix-shell --run "make -C FV3/wrapper test"
   nix-basic:
     docker:
       - image: nixos/nix
@@ -65,10 +58,14 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
-      - nix:
-          fortran-pytest-args: "-m 'not slow'"
-          wrapper-make-rule: "test_basic"
-  nix-additional:
+      - nix
+      - run:
+          name: Test fortran
+          command: nix-shell --run "pytest --native tests/pytest -v -m basic"
+      - run:
+          name: Test wrapper
+          command: nix-shell --run "make -C FV3/wrapper test_basic"
+  nix-coarse-graining:
     docker:
       - image: nixos/nix
     environment:
@@ -76,9 +73,52 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
       FSSPEC_GS_REQUESTER_PAYS: vcm-ml
     steps:
-      - nix:
-          fortran-pytest-args: "-m 'slow'"
-          wrapper-make-rule: "test_additional"
+      - nix
+      - run:
+          name: Test fortran
+          command: nix-shell --run "pytest --native tests/pytest -v -m coarse"
+      - run:
+          name: Test wrapper
+          command: nix-shell --run "make -C FV3/wrapper test_coarse_graining"
+  nix-emulation:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix
+      - run:
+          name: Test fortran
+          command: nix-shell --run "pytest --native tests/pytest -v -m emulation"
+      - run:
+          name: Test wrapper
+          command: nix-shell --run "make -C FV3/wrapper test_emulation"
+  nix-unmarked:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix
+      - run:
+          name: Test fortran
+          command: nix-shell --run "pytest --native tests/pytest -v -m 'not basic and not coarse and not emulation'"
+  nix-wrapper:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - nix
+      - run:
+          name: Test wrapper
+          command: nix-shell --run "make -C FV3/wrapper test"
   lint:
     docker:
       - image: circleci/python:3.9
@@ -150,32 +190,67 @@ workflows:
     jobs:
       - lint
       - nix-basic:
-          name: "Minimal native tests"
+          name: Minimal native fortran and wrapper tests
           filters:
             branches:
               ignore: master
-      - hold-nix-additional:
+      - hold-nix-coarse-graining:
+          name: Launch coarse graining tests
           type: approval
           filters:
             branches:
               ignore: master
-      - nix-additional:
-          name: "Additional native tests"
+      - nix-coarse-graining:
+          name: Coarse graining tests
           requires:
-            - Minimal native tests
-            - hold-nix-additional
+            - Minimal native fortran and wrapper tests
+            - Launch coarse graining tests
           filters:
             branches:
               ignore: master
-      - hold-build_default:
+      - hold-nix-emulation:
+          name: Launch emulation tests
           type: approval
           filters:
             branches:
               ignore: master
-      - build_default:
-          name: "Docker tests"
+      - nix-emulation:
+          name: Emulation tests
           requires:
-            - hold-build_default
+            - Minimal native fortran and wrapper tests
+            - Launch emulation tests
+          filters:
+            branches:
+              ignore: master
+      - hold-nix-unmarked:
+          name: Launch unmarked fortran tests
+          type: approval
+          filters:
+            branches:
+              ignore: master
+      - nix-unmarked:
+          name: Unmarked fortran tests
+          requires:
+            - Minimal native fortran and wrapper tests
+            - Launch unmarked fortran tests
+          filters:
+            branches:
+              ignore: master
+      - hold-nix-wrapper:
+          name: Launch wrapper tests
+          type: approval
+          filters:
+            branches:
+              ignore: master
+      - nix-wrapper:
+          name: Wrapper tests
+          requires:
+            - Minimal native fortran and wrapper tests
+            - Launch wrapper tests
+          filters:
+            branches:
+              ignore: master
+      - build_default
       - nix-full:
           name: "Full native tests"
           filters:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
       additional_dependencies: ["click==8.0.4"]
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8.git
     rev: 3.7.8
     hooks:
     - id: flake8

--- a/FV3/wrapper/Makefile
+++ b/FV3/wrapper/Makefile
@@ -73,6 +73,14 @@ test: ## run tests quickly with the default Python
 	pytest -v tests/pytest
 	pytest -v tests/test_all_mpi_requiring.py
 
+test_basic: ## run tests quickly with the default Python
+	pytest -v tests/pytest -m "not slow"
+	pytest -v tests/test_all_mpi_requiring.py -m "not slow"
+
+test_additional: ## run tests quickly with the default Python
+	pytest -v tests/pytest -m "slow"
+	pytest -v tests/test_all_mpi_requiring.py -m "slow"
+
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source fv3gfs setup.py test
 	coverage report -m

--- a/FV3/wrapper/Makefile
+++ b/FV3/wrapper/Makefile
@@ -73,13 +73,17 @@ test: ## run tests quickly with the default Python
 	pytest -v tests/pytest
 	pytest -v tests/test_all_mpi_requiring.py
 
-test_basic: ## run tests quickly with the default Python
-	pytest -v tests/pytest -m "not slow"
-	pytest -v tests/test_all_mpi_requiring.py -m "not slow"
+test_basic:
+	pytest -v tests/pytest -m basic
+	pytest -v tests/test_all_mpi_requiring.py -m basic
 
-test_additional: ## run tests quickly with the default Python
-	pytest -v tests/pytest -m "slow"
-	pytest -v tests/test_all_mpi_requiring.py -m "slow"
+test_coarse_graining:
+	pytest -v tests/pytest -m coarse
+	pytest -v tests/test_all_mpi_requiring.py -m coarse
+
+test_emulation:
+	pytest -v tests/pytest -m emulation
+	pytest -v tests/test_all_mpi_requiring.py -m emulation
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source fv3gfs setup.py test

--- a/FV3/wrapper/Makefile
+++ b/FV3/wrapper/Makefile
@@ -75,15 +75,12 @@ test: ## run tests quickly with the default Python
 
 test_basic:
 	pytest -v tests/pytest -m basic
-	pytest -v tests/test_all_mpi_requiring.py -m basic
 
 test_coarse_graining:
 	pytest -v tests/pytest -m coarse
-	pytest -v tests/test_all_mpi_requiring.py -m coarse
 
 test_emulation:
 	pytest -v tests/pytest -m emulation
-	pytest -v tests/test_all_mpi_requiring.py -m emulation
 
 coverage: ## check code coverage quickly with the default Python
 	coverage run --source fv3gfs setup.py test

--- a/FV3/wrapper/tests/pytest/test_regression.py
+++ b/FV3/wrapper/tests/pytest/test_regression.py
@@ -7,7 +7,21 @@ import hashlib
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 CONFIG_DIR = os.path.join(TEST_DIR, "config")
+SLOW_CONFIGS = [
+    "restart.yml",
+    "emulation.yml",
+    "baroclinic.yml",
+    "model-level-coarse-graining.yml",
+    "pressure-level-coarse-graining.yml",
+]
 config_filenames = os.listdir(CONFIG_DIR)
+config_params = []
+for filename in config_filenames:
+    if filename in SLOW_CONFIGS:
+        config_params.append(pytest.param(filename, pytest.mark.slow))
+    else:
+        config_params.append(filename)
+print(config_params)
 
 
 @pytest.fixture(params=config_filenames)
@@ -80,8 +94,7 @@ def test_fv3_wrapper_regression(regtest, tmpdir, config):
 def run_fv3(config, run_dir):
     fv3config.write_run_directory(config, str(run_dir))
     subprocess.check_call(
-        ["mpirun", "-n", "6", "fv3.exe"],
-        cwd=run_dir,
+        ["mpirun", "-n", "6", "fv3.exe"], cwd=run_dir,
     )
 
 

--- a/FV3/wrapper/tests/pytest/test_regression.py
+++ b/FV3/wrapper/tests/pytest/test_regression.py
@@ -23,7 +23,7 @@ for filename in config_filenames:
         config_params.append(filename)
 
 
-@pytest.fixture(params=config_filenames)
+@pytest.fixture(params=config_params)
 def config(request):
     config_filename = os.path.join(CONFIG_DIR, request.param)
     with open(config_filename, "r") as config_file:

--- a/FV3/wrapper/tests/pytest/test_regression.py
+++ b/FV3/wrapper/tests/pytest/test_regression.py
@@ -21,7 +21,6 @@ for filename in config_filenames:
         config_params.append(pytest.param(filename, pytest.mark.slow))
     else:
         config_params.append(filename)
-print(config_params)
 
 
 @pytest.fixture(params=config_filenames)

--- a/FV3/wrapper/tests/pytest/test_regression.py
+++ b/FV3/wrapper/tests/pytest/test_regression.py
@@ -7,23 +7,17 @@ import hashlib
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 CONFIG_DIR = os.path.join(TEST_DIR, "config")
-SLOW_CONFIGS = [
+CONFIG_PARAMS = [
+    pytest.param("default.yml", marks=pytest.mark.basic),
+    pytest.param("emulation.yml", marks=pytest.mark.emulation),
+    pytest.param("model-level-coarse-graining.yml", marks=pytest.mark.coarse),
+    pytest.param("pressure-level-coarse-graining.yml", marks=pytest.mark.coarse),
     "restart.yml",
-    "emulation.yml",
-    "baroclinic.yml",
-    "model-level-coarse-graining.yml",
-    "pressure-level-coarse-graining.yml",
+    "baroclinic.yml"
 ]
-config_filenames = os.listdir(CONFIG_DIR)
-config_params = []
-for filename in config_filenames:
-    if filename in SLOW_CONFIGS:
-        config_params.append(pytest.param(filename, marks=pytest.mark.slow))
-    else:
-        config_params.append(filename)
 
 
-@pytest.fixture(params=config_params)
+@pytest.fixture(params=CONFIG_PARAMS)
 def config(request):
     config_filename = os.path.join(CONFIG_DIR, request.param)
     with open(config_filename, "r") as config_file:

--- a/FV3/wrapper/tests/pytest/test_regression.py
+++ b/FV3/wrapper/tests/pytest/test_regression.py
@@ -18,7 +18,7 @@ config_filenames = os.listdir(CONFIG_DIR)
 config_params = []
 for filename in config_filenames:
     if filename in SLOW_CONFIGS:
-        config_params.append(pytest.param(filename, pytest.mark.slow))
+        config_params.append(pytest.param(filename, marks=pytest.mark.slow))
     else:
         config_params.append(filename)
 

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,21 @@ test_native: ## run native tests (all tools and build dependencies are assumed t
 		cd $(DIR)  && \
 		gcovr -d -r ../FV3 --html --html-details -o index.html
 
+test_native_fortran:
+	pytest --native tests/pytest -v
+
+test_native_fortran_basic:
+	pytest --native tests/pytest -v -m 'basic'
+
+test_native_fortran_coarse_graining:
+	pytest --native tests/pytest -v -m 'coarse'
+
+test_native_fortran_emulation:
+	pytest --native tests/pytest -v -m 'emulation'
+
+test_native_fortran_unmarked:
+	pytest --native tests/pytest -v -m 'not basic and not coarse and not emulation'
+
 test_wrapper:
 	$(MAKE) -C FV3/wrapper/ test
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    basic: marks tests considered basic enough to run on every PR
+    coarse: marks tests related to coarse-graining
+    emulation: marks tests related to emulation

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -201,9 +201,7 @@ def test_use_prescribed_sea_surface_properties(run_native, tmpdir):
     prescribed_ssts.create_sst_dataset(tmpdir)
     patch_files = prescribed_ssts.get_patch_files(tmpdir)
     config["patch_files"] = patch_files
-    config["namelist"]["gfs_physics_nml"][
-        "use_prescribed_sea_surface_properties"
-    ] = True
+    config["namelist"]["gfs_physics_nml"]["use_prescribed_sea_surface_properties"] = True
     config["namelist"]["fv_grid_nml"]["grid_file"] = "INPUT/grid_spec.nc"
 
     rundir = os.path.join(str(tmpdir), "rundir")
@@ -216,9 +214,7 @@ def test_use_prescribed_sea_surface_properties(run_native, tmpdir):
 PRESCRIBED_SST_ERRORS = {
     "MPP_OPEN:INPUT/sst.nc does not exist.": prescribed_ssts.grid_file_assets("C12")
     + [prescribed_ssts.data_table_asset()],
-    "sea_surface_temperature dataset not specified in data_table.": prescribed_ssts.grid_file_assets(
-        "C12"
-    ),
+    "sea_surface_temperature dataset not specified in data_table.": prescribed_ssts.grid_file_assets("C12"),
 }
 
 
@@ -227,14 +223,10 @@ PRESCRIBED_SST_ERRORS = {
     list(PRESCRIBED_SST_ERRORS.items()),
     ids=list(PRESCRIBED_SST_ERRORS.keys()),
 )
-def test_use_prescribed_sea_surface_properties_error(
-    run_native, tmpdir, message, patch_files
-):
+def test_use_prescribed_sea_surface_properties_error(run_native, tmpdir, message, patch_files):
     config = get_config("default.yml")
     config["patch_files"] = patch_files
-    config["namelist"]["gfs_physics_nml"][
-        "use_prescribed_sea_surface_properties"
-    ] = True
+    config["namelist"]["gfs_physics_nml"]["use_prescribed_sea_surface_properties"] = True
     config["namelist"]["fv_grid_nml"]["grid_file"] = "INPUT/grid_spec.nc"
     rundir = os.path.join(str(tmpdir), "rundir")
     result = run_native(config, rundir, error_expected=True)
@@ -394,7 +386,9 @@ def run_model_docker(rundir, model_image, n_processes, additional_env_vars=None)
     )
     with open(fv3out_filename, "w") as fv3out_f, open(fv3err_filename, "w") as fv3err_f:
         subprocess.check_call(
-            call, stdout=fv3out_f, stderr=fv3err_f,
+            call,
+            stdout=fv3out_f,
+            stderr=fv3err_f,
         )
 
 


### PR DESCRIPTION
The nix tests in this repo have gotten fairly time consuming.  For example [a recent workflow](https://app.circleci.com/pipelines/github/ai2cm/fv3gfs-fortran/2425/workflows/4be01fd5-caae-4229-97f9-34a2886f5875/jobs/4274) took an hour and five minutes.  This is more than double the typical amount of time required for the docker tests (see a comparable workflow [here](https://app.circleci.com/pipelines/github/ai2cm/fv3gfs-fortran/2423/workflows/c2667ebd-69d8-427a-94a6-49beb271bd48/jobs/4269)).  This PR breaks the nix tests up into a few categories:
- basic: these are tests that will be run upon every push to every PR.  These represent something of a bare minimum requirement: the model and wrapper build successfully, answers don't change for our default regression test, and the model restarts in a reproducible fashion.
- coarse: these are tests that pertain to coarse-graining code.
- emulation: these are tests that pertain to emulation code.
- unmarked: these are miscellaneous tests that relate to the fortran code, but are not likely to be impacted by every PR.
- wrapper: these are tests of the Python wrapper.

Only the "basic" tests are run automatically in each PR.  The other categories of tests can be launched by releasing their respective CircleCI holds; through caching they will automatically take advantage of the code compiled for the basic tests to save time and resources.  When a PR is merged to master, all tests will be run automatically just to make completely sure nothing has broken.  This is a similar strategy to what we use in fv3net regarding the integration tests.

After this refactor, the docker tests are the rate limiting step in CI, taking about 30 minutes.  The basic nix tests take about 20 minutes to complete.