### PR TITLE
Fix Zhao-Carr emulation piggy-back diagnostics

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -4670,14 +4670,13 @@ module module_physics_driver
             call set_state("total_precipitation", rain1)
             call set_state("ratio_of_snowfall_to_rainfall", Diag%sr)
             call set_state("tendency_of_rain_water_mixing_ratio_due_to_microphysics", rainp)
-
+            
             call call_function("emulation", "microphysics")
 
-            if (.not. Model%emulate_gscond_only) then
-              call apply_python_gscond_updates_to_diags(Diag, dqdt, dtdt, Model%ntcw, dtp)
-              if (Model%emulate_zc_microphysics) then
-                call apply_python_gscond_updates_to_tbd(Tbd)
-              end if
+            ! Need to apply the "gscond after last timestep".
+            ! no need for Stateout since final state is determined from precpd emulation.  
+            if (Model%emulate_zc_microphysics) then
+              call apply_python_gscond_updates_to_tbd(Tbd)
             end if
             
             if (Model%save_zc_microphysics) then

--- a/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -611,7 +611,8 @@ module module_physics_driver
         t_post_precpd, &
         tp_cpf
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1))  :: psp_cpf
+      real(kind=kind_phys), dimension(size(Grid%xlon,1))  :: psp_cpf, &
+        pr_post_precpd
 #endif
 
 !--- ALLOCATABLE ELEMENTS
@@ -4670,7 +4671,7 @@ module module_physics_driver
             call set_state("total_precipitation", rain1)
             call set_state("ratio_of_snowfall_to_rainfall", Diag%sr)
             call set_state("tendency_of_rain_water_mixing_ratio_due_to_microphysics", rainp)
-            
+
             call call_function("emulation", "microphysics")
 
             ! Need to apply the "gscond after last timestep".
@@ -4686,14 +4687,14 @@ module module_physics_driver
             call get_state("air_temperature_after_precpd", t_post_precpd)
             call get_state("specific_humidity_after_precpd", qv_post_precpd)
             call get_state("cloud_water_mixing_ratio_after_precpd", qc_post_precpd)
-            call get_state("total_precipitation", rain1)
+            call get_state("total_precipitation", pr_post_precpd)
 
             if (Model%ldiag3d) then
               Diag%zhao_carr_emulator%humidity = (qv_post_precpd(1:im,1:levs) - dqdt(:,:,1)) / dtp
               Diag%zhao_carr_emulator%cloud_water = (qc_post_precpd(1:im,1:levs) - dqdt(:,:,ntcw)) / dtp
               Diag%zhao_carr_emulator%temperature = (t_post_precpd(1:im,1:levs) - dtdt) / dtp
             end if
-            Diag%zhao_carr_emulator%surface_precipitation = rain1 / dtp * rhowater
+            Diag%zhao_carr_emulator%surface_precipitation = pr_post_precpd / dtp * rhowater
 
             ! apply emulator
             if (Model%emulate_zc_microphysics) then
@@ -4704,6 +4705,8 @@ module module_physics_driver
                   Stateout%gt0(i,k) = t_post_precpd(i,k)
                 enddo
               enddo
+
+              rain1(:) = pr_post_precpd
             endif
 
 #endif

--- a/FV3/wrapper/tests/pytest/_regtest_outputs/test_regression.test_fv3_wrapper_regression[emulation.yml].out
+++ b/FV3/wrapper/tests/pytest/_regtest_outputs/test_regression.test_fv3_wrapper_regression[emulation.yml].out
@@ -1,9 +1,9 @@
-./piggy.tile1.nc dea88b5ea3629e07c9be5b09726878f8
-./piggy.tile2.nc 1c6763a4a1c26ee40e1a6739a28cdc32
-./piggy.tile3.nc 7f4bdfae2ce6ab450f80dddd375dd1b7
-./piggy.tile4.nc 2269892488192479a45890dddb7f8a90
-./piggy.tile5.nc f9c582da9b14988c6f4025fef3e1d826
-./piggy.tile6.nc 2a54f04ea2ba80a13ea544c8f8fd0fd2
+./piggy.tile1.nc 0e3662e89de2a93e1557aca1c3cbeafc
+./piggy.tile2.nc 8b9c4cf60d9dd0a9259365eaf90ee64c
+./piggy.tile3.nc 6070b54c6caf45327ed59b35e1535fc0
+./piggy.tile4.nc e11678c03b41d4a194001abcea69141b
+./piggy.tile5.nc 0ddd010da1a7165a4258cffe5c76b105
+./piggy.tile6.nc 33de5bdc7ae9772db19636bd4c8628dc
 INPUT/gfs_ctrl.nc 72479dcd4e5e38f802cd1ac9bc71aa8b
 INPUT/gfs_data.tile1.nc c0bba587540ba06a45a16ef06134224b
 INPUT/gfs_data.tile2.nc d14b7b0ffc2853431014e56feaf7476a


### PR DESCRIPTION
I found three inconsistencies in our Zhao-Carr code that were messing up the diagnostics.  Each one is addressed in a commit if it's easier to review that way.  

1.  The offline fortran output to the diagnostics had an improper adjustment where the gscond emulated state was removed before adding back the total ZC update.  The offline case doesn't have the emulation updated state, so it shouldn't apply.
2. The online fortran diagnostics for precpd were based off the scheme run with the emulated gscond outputs as inputs.  For our emulation setup, we don't currently base the precpd prediction off the emulated gscond outputs so the piggy-backed comparison is not consistent.
3. The precipitation output was being applied from the emulator in the offline case

To remedy this, I made a few updates to the emulation control flow.
* Change `emulate_gscond_only` to apply to only that case.  I.e., it will only update the state with gscond values if that's the only emulator being used, and it does so before the fortran `precpd` scheme is run.
    * this change is not necessarily backwards compatible because our previous configurations use both `emulate_gscond_only` and `emulate_zc_microphysics` to true to call both emulators.  From now on, it'll only expect one or the other to be `True`, and this seems more understandable given the naming.
*  Ensure that when `emulate_zc_microphysics` is `True`, the `<field>_after_last_gscond` is updated and no state updates happen before the Fortran subroutines have been called
* Fix the emulated rain to only be output when running with `emulate_zc_microphysics=True` 