### PR TITLE
Add Python-wrapped versions of the wind transformation subroutines

### DIFF
--- a/FV3/atmos_cubed_sphere/tools/external_ic.F90
+++ b/FV3/atmos_cubed_sphere/tools/external_ic.F90
@@ -199,7 +199,7 @@ module external_ic_mod
    real(kind=R_GRID), parameter :: cnst_0p20=0.20d0
    real :: deg2rad
    character (len = 80) :: source   ! This tells what the input source was for the data
-   public get_external_ic, get_cubed_sphere_terrain
+   public get_external_ic, get_cubed_sphere_terrain, cubed_a2d
 
 ! version number of this module
 ! Include variable "version" to be written to log file.

--- a/FV3/wrapper/fv3gfs/wrapper/__init__.py
+++ b/FV3/wrapper/fv3gfs/wrapper/__init__.py
@@ -20,7 +20,9 @@ from ._wrapper import (
     DiagnosticInfo,
     step_pre_radiation,
     step_radiation,
-    step_post_radiation_physics
+    step_post_radiation_physics,
+    transform_agrid_winds_to_dgrid_winds,
+    transform_dgrid_winds_to_agrid_winds
 )
 from ._restart import get_restart_names, open_restart
 from . import examples

--- a/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
+++ b/FV3/wrapper/fv3gfs/wrapper/physics_properties.json
@@ -1,5 +1,19 @@
 [
     {
+        "name": "northward_wind_before_physics",
+        "fortran_name": "vgrs",
+        "units": "m/s",
+        "container": "Statein",
+        "dims": ["z", "y", "x"]
+    },
+    {
+        "name": "eastward_wind_before_physics",
+        "fortran_name": "ugrs",
+        "units": "m/s",
+        "container": "Statein",
+        "dims": ["z", "y", "x"]
+    },
+    {
         "name": "air_temperature_after_physics",
         "fortran_name": "gt0",
         "units": "K",

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -607,14 +607,15 @@ def transform_agrid_winds_to_dgrid_winds(ua, va):
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
 
+    units = ua.units
     ua = ua.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
     va = va.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
     buffer_ua = np.ascontiguousarray(ua.view[:])
     buffer_va = np.ascontiguousarray(va.view[:])
 
     allocator = get_quantity_factory()
-    u = allocator.empty([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
-    v = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_INTERFACE_DIM], "m/s", dtype=real_type)
+    u = allocator.empty([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM], units, dtype=real_type)
+    v = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_INTERFACE_DIM], units, dtype=real_type)
 
     with pace.util.recv_buffer(u.np.empty, u.view[:]) as buffer_u, pace.util.recv_buffer(v.np.empty, v.view[:]) as buffer_v:
         transform_agrid_winds_to_dgrid_winds_subroutine(&buffer_ua[0, 0, 0], &buffer_va[0, 0, 0], &buffer_u[0, 0, 0], &buffer_v[0, 0, 0])
@@ -644,14 +645,15 @@ def transform_dgrid_winds_to_agrid_winds(u, v):
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
 
+    units = u.units
     u = u.transpose([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM])
     v = v.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_INTERFACE_DIM])
     buffer_u = np.ascontiguousarray(u.view[:])
     buffer_v = np.ascontiguousarray(v.view[:])
 
     allocator = get_quantity_factory()
-    ua = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
-    va = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
+    ua = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], units, dtype=real_type)
+    va = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], units, dtype=real_type)
 
     with pace.util.recv_buffer(ua.np.empty, ua.view[:]) as buffer_ua, pace.util.recv_buffer(va.np.empty, va.view[:]) as buffer_va:
         transform_dgrid_winds_to_agrid_winds_subroutine(&buffer_u[0, 0, 0], &buffer_v[0, 0, 0], &buffer_ua[0, 0, 0], &buffer_va[0, 0, 0])

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -607,8 +607,8 @@ def transform_agrid_winds_to_dgrid_winds(ua, va):
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
 
-    ua = ua.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
-    va = va.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    ua = ua.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
+    va = va.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
     buffer_ua = np.ascontiguousarray(ua.view[:])
     buffer_va = np.ascontiguousarray(va.view[:])
 
@@ -644,8 +644,8 @@ def transform_dgrid_winds_to_agrid_winds(u, v):
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
 
-    u = u.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
-    v = v.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    u = u.transpose([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM])
+    v = v.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_INTERFACE_DIM])
     buffer_u = np.ascontiguousarray(u.view[:])
     buffer_v = np.ascontiguousarray(v.view[:])
 

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -586,7 +586,22 @@ def step_post_radiation_physics():
 
 
 def transform_agrid_winds_to_dgrid_winds(ua, va):
-    """ua and va are quantities"""
+    """Transform A-grid lat-lon winds to D-grid cubed-sphere winds.
+
+    This function wraps the cubed_a2d subroutine from the fortran model, making
+    it possible to call from Python without having to provide information about
+    the grid or domain decomposition.
+
+    Args:
+        ua : Quantity
+            The eastward wind defined on the A-grid
+        va : Quantity
+            The northward wind defined on the A-grid
+
+    Returns:
+        u, v : Quantity, Quantity
+            The cubed-sphere components of the wind defined on the D-grid
+    """
     cdef REAL_t[:, :, :] buffer_ua
     cdef REAL_t[:, :, :] buffer_va
     cdef REAL_t[:, :, :] buffer_u
@@ -608,7 +623,22 @@ def transform_agrid_winds_to_dgrid_winds(ua, va):
 
 
 def transform_dgrid_winds_to_agrid_winds(u, v):
-    """ua and va are quantities"""
+    """Transform D-grid cubed-sphere winds to A-grid lat-lon winds.
+
+    This function wraps the cubed_to_latlon subroutine from the fortran model,
+    making it possible to call from Python without having to provide information
+    about the grid or domain decomposition.
+
+    Args:
+        u : Quantity
+            The x-wind defined on the D-grid
+        v : Quantity
+            The y-wind defined on the D-grid
+
+    Returns:
+        ua, va : Quantity, Quantity
+            The lat-lon components of the wind defined on the A-grid
+    """
     cdef REAL_t[:, :, :] buffer_ua
     cdef REAL_t[:, :, :] buffer_va
     cdef REAL_t[:, :, :] buffer_u

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -64,6 +64,8 @@ cdef extern:
 {% for item in flagstruct_properties %}
     void get_{{ item.fortran_name }}({{item.type_cython}} *{{ item.fortran_name }}_out)
 {% endfor %}
+    void transform_agrid_winds_to_dgrid_winds_subroutine(REAL_t *ua, REAL_t *va, REAL_t *u, REAL_t *v)
+    void transform_dgrid_winds_to_agrid_winds_subroutine(REAL_t *u, REAL_t *v, REAL_t *ua, REAL_t *va)
 
 cdef get_quantity_factory():
     cdef int nx, ny, nz, nz_soil, n_topo_variables
@@ -581,3 +583,47 @@ def step_post_radiation_physics():
     """Compute Post-radiation physics (e.g. moist physics turbulence)"""
     # TODO ensure that IPD_control.first_step is set in this routine
     do_physics()
+
+
+def transform_agrid_winds_to_dgrid_winds(ua, va):
+    """ua and va are quantities"""
+    cdef REAL_t[:, :, :] buffer_ua
+    cdef REAL_t[:, :, :] buffer_va
+    cdef REAL_t[:, :, :] buffer_u
+    cdef REAL_t[:, :, :] buffer_v
+
+    ua = ua.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    va = va.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    buffer_ua = np.ascontiguousarray(ua.view[:])
+    buffer_va = np.ascontiguousarray(va.view[:])
+
+    allocator = get_quantity_factory()
+    u = allocator.empty([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
+    v = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_INTERFACE_DIM], "m/s", dtype=real_type)
+
+    with pace.util.recv_buffer(u.np.empty, u.view[:]) as buffer_u, pace.util.recv_buffer(v.np.empty, v.view[:]) as buffer_v:
+        transform_agrid_winds_to_dgrid_winds_subroutine(&buffer_ua[0, 0, 0], &buffer_va[0, 0, 0], &buffer_u[0, 0, 0], &buffer_v[0, 0, 0])
+
+    return u, v
+
+
+def transform_dgrid_winds_to_agrid_winds(u, v):
+    """ua and va are quantities"""
+    cdef REAL_t[:, :, :] buffer_ua
+    cdef REAL_t[:, :, :] buffer_va
+    cdef REAL_t[:, :, :] buffer_u
+    cdef REAL_t[:, :, :] buffer_v
+
+    u = u.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    v = v.transpose([pace.util.Z_DIMS, pace.util.Y_DIMS, pace.util.X_DIMS])
+    buffer_u = np.ascontiguousarray(u.view[:])
+    buffer_v = np.ascontiguousarray(v.view[:])
+
+    allocator = get_quantity_factory()
+    ua = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
+    va = allocator.empty([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM], "m/s", dtype=real_type)
+
+    with pace.util.recv_buffer(ua.np.empty, ua.view[:]) as buffer_ua, pace.util.recv_buffer(va.np.empty, va.view[:]) as buffer_va:
+        transform_dgrid_winds_to_agrid_winds_subroutine(&buffer_u[0, 0, 0], &buffer_v[0, 0, 0], &buffer_ua[0, 0, 0], &buffer_va[0, 0, 0])
+
+    return ua, va

--- a/FV3/wrapper/templates/_wrapper.pyx
+++ b/FV3/wrapper/templates/_wrapper.pyx
@@ -607,6 +607,12 @@ def transform_agrid_winds_to_dgrid_winds(ua, va):
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
 
+    if ua.units != va.units:
+        raise ValueError(
+            f"Input wind components have differing units from each other. "
+            f"ua has units {ua.units!r} and va has units {va.units!r}."
+        )
+
     units = ua.units
     ua = ua.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
     va = va.transpose([pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM])
@@ -644,6 +650,12 @@ def transform_dgrid_winds_to_agrid_winds(u, v):
     cdef REAL_t[:, :, :] buffer_va
     cdef REAL_t[:, :, :] buffer_u
     cdef REAL_t[:, :, :] buffer_v
+
+    if u.units != v.units:
+        raise ValueError(
+            f"Input wind components have differing units from each other. "
+            f"u has units {u.units!r} and v has units {v.units!r}."
+        )
 
     units = u.units
     u = u.transpose([pace.util.Z_DIM, pace.util.Y_INTERFACE_DIM, pace.util.X_DIM])

--- a/FV3/wrapper/templates/dynamics_data.F90
+++ b/FV3/wrapper/templates/dynamics_data.F90
@@ -144,10 +144,10 @@ contains
         allocate(u_halo(isd:ied,jsd:jed+1,1:npz))
         allocate(v_halo(isd:ied+1,jsd:jed,1:npz))
 
+        ! Note we do not need to do a halo update here, since cubed_a2d takes
+        ! of this internally.
         ua_halo(is:ie,js:je,1:npz) = ua
         va_halo(is:ie,js:je,1:npz) = va
-        call mpp_update_domains(ua_halo, Atm(mytile)%domain, complete=.false.)
-        call mpp_update_domains(va_halo, Atm(mytile)%domain, complete=.true.)
 
         call cubed_a2d(&
             npx, &

--- a/FV3/wrapper/templates/dynamics_data.F90
+++ b/FV3/wrapper/templates/dynamics_data.F90
@@ -117,8 +117,8 @@ contains
     end subroutine get_tracer_name
 
     subroutine transform_agrid_winds_to_dgrid_winds_subroutine(ua, va, u, v) bind(c)
-        ! Wraps the internal cubed_a2d subroutine in a more convenient way, handling halos
-        ! halo updates, and the additional grid arguments within fortran for convenience.
+        ! Wraps the internal cubed_a2d subroutine in a more convenient way, handling
+        ! halo updates and the additional grid arguments within fortran for convenience.
         real, intent(in), dimension(i_start():i_end(),j_start():j_end(),1:nz()) :: ua, va
         real, intent(out), dimension(i_start():i_end(),j_start():j_end()+1,1:nz()) :: u
         real, intent(out), dimension(i_start():i_end()+1,j_start():j_end(),1:nz()) :: v
@@ -149,13 +149,27 @@ contains
         call mpp_update_domains(ua_halo, Atm(mytile)%domain, complete=.false.)
         call mpp_update_domains(va_halo, Atm(mytile)%domain, complete=.true.)
 
-        call cubed_a2d(npx, npy, npz, ua_halo, va_halo, u_halo, v_halo, Atm(mytile)%gridstruct, Atm(mytile)%domain, Atm(mytile)%bd)
+        call cubed_a2d(&
+            npx, &
+            npy, &
+            npz, &
+            ua_halo, &
+            va_halo, &
+            u_halo, &
+            v_halo, &
+            Atm(mytile)%gridstruct, &
+            Atm(mytile)%domain, &
+            Atm(mytile)%bd &
+        )
 
         u = u_halo(is:ie,js:je+1,1:npz)
         v = v_halo(is:ie+1,js:je,1:npz)
     end subroutine transform_agrid_winds_to_dgrid_winds_subroutine
 
     subroutine transform_dgrid_winds_to_agrid_winds_subroutine(u, v, ua, va) bind(c)
+        ! Wraps the internal cubed_to_latlon subroutine in a more convenient way, 
+        ! handling halo updates and the additional grid arguments within fortran
+        ! for convenience.
         real, intent(in), dimension(i_start():i_end(),j_start():j_end()+1,1:nz()) :: u
         real, intent(in), dimension(i_start():i_end()+1,j_start():j_end(),1:nz()) :: v
         real, intent(out), dimension(i_start():i_end(),j_start():j_end(),1:nz()) :: ua, va
@@ -188,7 +202,22 @@ contains
         call start_group_halo_update(i_pack, u_halo, v_halo, Atm(mytile)%domain, gridtype=DGRID_NE)
         call complete_group_halo_update(i_pack, Atm(mytile)%domain)
 
-        call cubed_to_latlon(u_halo, v_halo, ua_halo, va_halo, Atm(mytile)%gridstruct, npx, npy, npz, mode, Atm(mytile)%gridstruct%grid_type, Atm(mytile)%domain, Atm(mytile)%gridstruct%nested, Atm(mytile)%flagstruct%c2l_ord, Atm(mytile)%bd)
+        call cubed_to_latlon(&
+            u_halo, &
+            v_halo, &
+            ua_halo, &
+            va_halo, &
+            Atm(mytile)%gridstruct, &
+            npx, &
+            npy, &
+            npz, &
+            mode, &
+            Atm(mytile)%gridstruct%grid_type, &
+            Atm(mytile)%domain, &
+            Atm(mytile)%gridstruct%nested, &
+            Atm(mytile)%flagstruct%c2l_ord, &
+            Atm(mytile)%bd &
+        )
 
         ua = ua_halo(is:ie,js:je,1:npz)
         va = va_halo(is:ie,js:je,1:npz)

--- a/FV3/wrapper/templates/dynamics_data.F90
+++ b/FV3/wrapper/templates/dynamics_data.F90
@@ -1,6 +1,10 @@
 module dynamics_data_mod
 
 use atmosphere_mod, only: Atm, mytile
+use external_ic_mod, only: cubed_a2d
+use fv_grid_utils_mod, only: cubed_to_latlon
+use mpp_domains_mod, only: DGRID_NE, mpp_update_domains
+use fv_mp_mod,       only: start_group_halo_update, complete_group_halo_update, group_halo_update_type
 use tracer_manager_mod, only: get_tracer_names, get_number_tracers, get_tracer_index
 use field_manager_mod,  only: MODEL_ATMOS
 use iso_c_binding
@@ -111,5 +115,83 @@ contains
             tracer_units_out(i) = tracer_units(i:i)
         enddo
     end subroutine get_tracer_name
+
+    subroutine transform_agrid_winds_to_dgrid_winds_subroutine(ua, va, u, v) bind(c)
+        ! Wraps the internal cubed_a2d subroutine in a more convenient way, handling halos
+        ! halo updates, and the additional grid arguments within fortran for convenience.
+        real, intent(in), dimension(i_start():i_end(),j_start():j_end(),1:nz()) :: ua, va
+        real, intent(out), dimension(i_start():i_end(),j_start():j_end()+1,1:nz()) :: u
+        real, intent(out), dimension(i_start():i_end()+1,j_start():j_end(),1:nz()) :: v
+
+        real, allocatable, dimension(:,:,:) :: ua_halo, va_halo, u_halo, v_halo
+
+        integer :: is, ie, js, je, isd, ied, jsd, jed, npx, npy, npz
+
+        is = i_start()
+        ie = i_end()
+        js = j_start()
+        je = j_end()
+        isd = Atm(mytile)%bd%isd
+        ied = Atm(mytile)%bd%ied
+        jsd = Atm(mytile)%bd%jsd
+        jed = Atm(mytile)%bd%jed
+        npx = Atm(mytile)%npx
+        npy = Atm(mytile)%npy
+        npz = nz()
+
+        allocate(ua_halo(isd:ied,jsd:jed,1:npz))
+        allocate(va_halo(isd:ied,jsd:jed,1:npz))
+        allocate(u_halo(isd:ied,jsd:jed+1,1:npz))
+        allocate(v_halo(isd:ied+1,jsd:jed,1:npz))
+
+        ua_halo(is:ie,js:je,1:npz) = ua
+        va_halo(is:ie,js:je,1:npz) = va
+        call mpp_update_domains(ua_halo, Atm(mytile)%domain, complete=.false.)
+        call mpp_update_domains(va_halo, Atm(mytile)%domain, complete=.true.)
+
+        call cubed_a2d(npx, npy, npz, ua_halo, va_halo, u_halo, v_halo, Atm(mytile)%gridstruct, Atm(mytile)%domain, Atm(mytile)%bd)
+
+        u = u_halo(is:ie,js:je+1,1:npz)
+        v = v_halo(is:ie+1,js:je,1:npz)
+    end subroutine transform_agrid_winds_to_dgrid_winds_subroutine
+
+    subroutine transform_dgrid_winds_to_agrid_winds_subroutine(u, v, ua, va) bind(c)
+        real, intent(in), dimension(i_start():i_end(),j_start():j_end()+1,1:nz()) :: u
+        real, intent(in), dimension(i_start():i_end()+1,j_start():j_end(),1:nz()) :: v
+        real, intent(out), dimension(i_start():i_end(),j_start():j_end(),1:nz()) :: ua, va
+
+        real, allocatable, dimension(:,:,:) :: ua_halo, va_halo, u_halo, v_halo
+
+        type(group_halo_update_type), save :: i_pack
+        integer :: is, ie, js, je, isd, ied, jsd, jed, npx, npy, npz, mode
+
+        is = i_start()
+        ie = i_end()
+        js = j_start()
+        je = j_end()
+        isd = Atm(mytile)%bd%isd
+        ied = Atm(mytile)%bd%ied
+        jsd = Atm(mytile)%bd%jsd
+        jed = Atm(mytile)%bd%jed
+        npx = Atm(mytile)%npx
+        npy = Atm(mytile)%npy
+        npz = nz()
+        mode = 1
+
+        allocate(ua_halo(isd:ied,jsd:jed,1:npz))
+        allocate(va_halo(isd:ied,jsd:jed,1:npz))
+        allocate(u_halo(isd:ied,jsd:jed+1,1:npz))
+        allocate(v_halo(isd:ied+1,jsd:jed,1:npz))
+
+        u_halo(is:ie,js:je+1,1:npz) = u
+        v_halo(is:ie+1,js:je,1:npz) = v
+        call start_group_halo_update(i_pack, u_halo, v_halo, Atm(mytile)%domain, gridtype=DGRID_NE)
+        call complete_group_halo_update(i_pack, Atm(mytile)%domain)
+
+        call cubed_to_latlon(u_halo, v_halo, ua_halo, va_halo, Atm(mytile)%gridstruct, npx, npy, npz, mode, Atm(mytile)%gridstruct%grid_type, Atm(mytile)%domain, Atm(mytile)%gridstruct%nested, Atm(mytile)%flagstruct%c2l_ord, Atm(mytile)%bd)
+
+        ua = ua_halo(is:ie,js:je,1:npz)
+        va = va_halo(is:ie,js:je,1:npz)
+    end subroutine transform_dgrid_winds_to_agrid_winds_subroutine
 
 end module dynamics_data_mod

--- a/FV3/wrapper/tests/test_all_mpi_requiring.py
+++ b/FV3/wrapper/tests/test_all_mpi_requiring.py
@@ -46,6 +46,9 @@ class UsingMPITests(unittest.TestCase):
     def test_set_ocean_surface_temperature(self):
         run_unittest_script("test_set_ocean_surface_temperature.py")
 
+    def test_wind_transformations(self):
+        run_unittest_script("test_wind_transformations.py")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/FV3/wrapper/tests/test_wind_transformations.py
+++ b/FV3/wrapper/tests/test_wind_transformations.py
@@ -87,8 +87,8 @@ class WindTransformationTests(unittest.TestCase):
         v_increment.view[:] = v_increment.view[:][::-1, :, :]
 
         (
-            x_wind_increment_python,
-            y_wind_increment_python,
+            x_wind_physics_increment,
+            y_wind_physics_increment,
         ) = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(
             u_increment, v_increment
         )
@@ -99,11 +99,11 @@ class WindTransformationTests(unittest.TestCase):
         y_wind_after_physics = updated_dynamical_core_state["y_wind"]
 
         np.testing.assert_allclose(
-            x_wind_before_physics.view[:] + x_wind_increment_python.view[:],
+            x_wind_before_physics.view[:] + x_wind_physics_increment.view[:],
             x_wind_after_physics.view[:],
         )
         np.testing.assert_allclose(
-            y_wind_before_physics.view[:] + y_wind_increment_python.view[:],
+            y_wind_before_physics.view[:] + y_wind_physics_increment.view[:],
             y_wind_after_physics.view[:],
         )
 
@@ -113,7 +113,8 @@ if __name__ == "__main__":
     # Deactivate fv_sg_adj for these tests. fv_sg_adj can otherwise introduce an
     # additional momentum tendency on the A-grid winds that is not accounted for
     # by the difference between the A-grid winds at the start of the physics and
-    # the A-grid winds at the end of the physics.  This is just to make the test
-    # simpler and is orthogonal to the functionality we are testing here.
+    # the A-grid winds at the end of the physics.  This is just to make the
+    # A-grid to D-grid test simpler and is orthogonal to the functionality we
+    # are testing here.
     config["namelist"]["fv_core_nml"]["fv_sg_adj"] = -1
     main(test_dir, config)

--- a/FV3/wrapper/tests/test_wind_transformations.py
+++ b/FV3/wrapper/tests/test_wind_transformations.py
@@ -111,11 +111,16 @@ class WindTransformationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     config = get_default_config()
-    # Deactivate fv_sg_adj for these tests. fv_sg_adj can otherwise introduce an
-    # additional momentum tendency on the A-grid winds that is not accounted for
-    # by the difference between the A-grid winds at the start of the physics and
-    # the A-grid winds at the end of the physics.  This is just to make the
-    # A-grid to D-grid test simpler and is orthogonal to the functionality we
-    # are testing here.
+    # Deactivate fv_subgrid_z for these tests.  Due to how the
+    # atmosphere_state_update subroutine is implemented in the atmosphere.F90
+    # module, the A-grid wind tendencies from the fv_subgrid_z subroutine are
+    # lumped into the A-grid wind tendencies from the physics.  We do not
+    # currently have easy access to the fv_subgrid_z tendency from the wrapper,
+    # and rather than implement that for the sake of the A-grid to D-grid
+    # transformation test, it is easier to simply turn it off. This way the
+    # A-grid wind tendency that is applied in the atmosphere_state_update
+    # subroutine comes only from the difference in the A-grid winds at the start
+    # of the physics and at the end of the physics, which is something that we
+    # can easily compute using existing wrapper infrastructure.
     config["namelist"]["fv_core_nml"]["fv_sg_adj"] = -1
     main(test_dir, config)

--- a/FV3/wrapper/tests/test_wind_transformations.py
+++ b/FV3/wrapper/tests/test_wind_transformations.py
@@ -50,7 +50,7 @@ class WindTransformationTests(unittest.TestCase):
 
         fv3gfs.wrapper.step_dynamics()
         fv3gfs.wrapper.compute_physics()
-        post_physics_state = fv3gfs.wrapper.get_state(
+        pre_applied_physics_state = fv3gfs.wrapper.get_state(
             [
                 "x_wind",
                 "y_wind",
@@ -60,21 +60,21 @@ class WindTransformationTests(unittest.TestCase):
                 "northward_wind_after_physics",
             ]
         )
-        x_wind_before_physics = post_physics_state["x_wind"]
-        y_wind_before_physics = post_physics_state["y_wind"]
+        x_wind_before_physics = pre_applied_physics_state["x_wind"]
+        y_wind_before_physics = pre_applied_physics_state["y_wind"]
 
-        u_before_physics = post_physics_state["eastward_wind_before_physics"]
-        u_after_physics = post_physics_state["eastward_wind_after_physics"]
+        u_before_physics = pre_applied_physics_state["eastward_wind_before_physics"]
+        u_after_physics = pre_applied_physics_state["eastward_wind_after_physics"]
 
-        v_before_physics = post_physics_state["northward_wind_before_physics"]
-        v_after_physics = post_physics_state["northward_wind_after_physics"]
+        v_before_physics = pre_applied_physics_state["northward_wind_before_physics"]
+        v_after_physics = pre_applied_physics_state["northward_wind_after_physics"]
 
         # Note that 3D variables from the physics component of the model have
         # their vertical dimension flipped with respect to 3D variables from the
         # dynamical core.  Therefore we need to flip the vertical dimension of
         # these A-grid wind increments so that when we convert them to D-grid
         # wind increments, they align with the D-grid winds in the dynamical
-        # core. 
+        # core.
         #
         # deepcopy calls here are used out of convenience to construct Quantity
         # objects of the same shape and metadata as others.  Their data is

--- a/FV3/wrapper/tests/test_wind_transformations.py
+++ b/FV3/wrapper/tests/test_wind_transformations.py
@@ -1,0 +1,75 @@
+import unittest
+import os
+import numpy as np
+import fv3gfs.wrapper
+from mpi4py import MPI
+from util import (
+    get_default_config,
+    main,
+)
+
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class WindTransformationTests(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(WindTransformationTests, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        MPI.COMM_WORLD.barrier()
+
+    def test_transform_dgrid_winds_to_agrid_winds(self):
+        fv3gfs.wrapper.step()
+        state = fv3gfs.wrapper.get_state(
+            ["x_wind", "y_wind", "eastward_wind", "northward_wind"]
+        )
+        x_wind_fortran = state["x_wind"]
+        y_wind_fortran = state["y_wind"]
+        u_fortran = state["eastward_wind"]
+        v_fortran = state["northward_wind"]
+
+        # We expect exact reproduction of the fortran here, since the wrapper wraps the same routine
+        # that is used to convert the D-grid winds to the A-grid winds within the fortran model.
+        u_wrapper, v_wrapper = fv3gfs.wrapper.transform_dgrid_winds_to_agrid_winds(
+            x_wind_fortran, y_wind_fortran
+        )
+        np.testing.assert_equal(u_wrapper.view[:], u_fortran.view[:])
+        np.testing.assert_equal(v_wrapper.view[:], v_fortran.view[:])
+
+    def test_transform_agrid_winds_to_dgrid_winds(self):
+        fv3gfs.wrapper.step()
+        state = fv3gfs.wrapper.get_state(
+            ["x_wind", "y_wind", "eastward_wind", "northward_wind"]
+        )
+        x_wind_fortran = state["x_wind"]
+        y_wind_fortran = state["y_wind"]
+        u_fortran = state["eastward_wind"]
+        v_fortran = state["northward_wind"]
+
+        # Here we do not expect an exact match, because the cubed_a2d subroutine is not an exact
+        # inverse of the cubed_to_latlon subroutine.  Errors can actually be non-trivial, so the
+        # tolerance must be large (30 m/s).  In general the cubed_a2d subroutine tends to produce
+        # a smoother wind field than the native winds.
+        #
+        # TODO: to my eye the plotted transformed wind field looks reasonable, but the tolerance
+        # required is surprisingly large.  We should check more carefully to make sure things
+        # are operating as we expect here.
+        (
+            x_wind_wrapper,
+            y_wind_wrapper,
+        ) = fv3gfs.wrapper.transform_agrid_winds_to_dgrid_winds(u_fortran, v_fortran)
+        np.testing.assert_allclose(
+            x_wind_wrapper.view[:], x_wind_fortran.view[:], atol=30
+        )
+        np.testing.assert_allclose(
+            y_wind_wrapper.view[:], y_wind_fortran.view[:], atol=30
+        )
+
+
+if __name__ == "__main__":
+    config = get_default_config()
+    main(test_dir, config)

--- a/FV3/wrapper/tests/test_wind_transformations.py
+++ b/FV3/wrapper/tests/test_wind_transformations.py
@@ -75,9 +75,10 @@ class WindTransformationTests(unittest.TestCase):
         # these A-grid wind increments so that when we convert them to D-grid
         # wind increments, they align with the D-grid winds in the dynamical
         # core. 
-        # 
-        # TODO: there is probably an easier way to construct a Quantity object
-        # with similar properties to an existing one.
+        #
+        # deepcopy calls here are used out of convenience to construct Quantity
+        # objects of the same shape and metadata as others.  Their data is
+        # overwritten immediately.
         u_increment = deepcopy(u_after_physics)
         u_increment.view[:] = u_after_physics.view[:] - u_before_physics.view[:]
         u_increment.view[:] = u_increment.view[:][::-1, :, :]


### PR DESCRIPTION
This PR adds Python-wrapped versions of the wind transformation subroutines contained in the dynamical core.  This will allow us to more easily convert the horizontal winds between the D-grid and A-grid from within a Python-wrapper runfile.  

### Motivation

The primary motivation here is to enable us to more flexibly translate wind tendency updates made on the A-grid to the D-grid (e.g. to enable nudging toward A-grid winds or applying ML-predicted tendency corrections without modifying fields in the physics output state).  For this we technically only need the A to D grid transformation, but the D to A grid transformation could potentially have use-cases as well (e.g. if we ever wanted to directly output A-grid wind nudging tendencies when we were nudging to D-grid winds).

### Testing

The `cubed_to_latlon` and `cubed_a2d` subroutines are not exact inverses of each other, which means roundtrip tests are awkward (they require surprisingly large tolerances).  As an alternative we instead leverage steps where these subroutines (or [copies of these subroutines...](https://github.com/ai2cm/fv3gfs-fortran/blob/2a3ea739723d6152fd03d419c76d25741f7fa9da/FV3/atmos_cubed_sphere/model/fv_update_phys.F90#L892-L1076)) are already used within the dynamical core and verify that we are able to reproduce those results from within Python.
- In the case of testing `cubed_to_latlon` this means verifying that we can recover `Atm%ua` and `Atm%va` from `Atm%u` and `Atm%v`.
- In the case of testing `cubed_a2d` this means verifying that we can perform the physics increment of the dynamical core winds from within Python and get the same result as when it is done in fortran.

