### PR TITLE
Address some issues related to pressure thickness diagnostics

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -65,7 +65,8 @@ module fv_arrays_mod
            id_qdt, id_aam, id_amdt,                               &
            id_acly, id_acl, id_acl2,                              &
            id_dbz, id_maxdbz, id_basedbz, id_dbz4km, id_dbztop, id_dbz_m10C, &
-           id_ctz, id_w1km, id_wmaxup, id_wmaxdn, id_cape, id_cin, id_diss
+           id_ctz, id_w1km, id_wmaxup, id_wmaxdn, id_cape, id_cin, id_diss, &
+           id_total_delp
 
  integer :: id_lagrangian_tendency_of_hydrostatic_pressure
 

--- a/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/coarse_grained_diagnostics.F90
@@ -109,8 +109,8 @@ contains
     index = index + 1
     coarse_diagnostics(index)%axes = 3
     coarse_diagnostics(index)%module_name = DYNAMICS
-    coarse_diagnostics(index)%name = 'delp_coarse'
-    coarse_diagnostics(index)%description = 'coarse-grained pressure thickness'
+    coarse_diagnostics(index)%name = 'total_delp_coarse'
+    coarse_diagnostics(index)%description = 'coarse-grained total pressure thickness including hydrometeor mass'
     coarse_diagnostics(index)%units = 'Pa'
     coarse_diagnostics(index)%reduction_method = AREA_WEIGHTED
     coarse_diagnostics(index)%always_model_level_coarse_grain = .true.
@@ -1068,7 +1068,7 @@ contains
        if ((coarse_diagnostics(index)%axes == 3) .and. & 
            (trim(coarse_diagnostics(index)%reduction_method) .eq. MASS_WEIGHTED) .and. &
            (coarse_diagnostics(index)%id > 0) .and. &
-           (trim(coarsening_strategy) .eq. MODEL_LEVEL)) then
+           ((trim(coarsening_strategy) .eq. MODEL_LEVEL) .or. coarse_diagnostics(index)%always_model_level_coarse_grain)) then
            need_mass_array = .true.
            exit
        endif

--- a/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
+++ b/FV3/atmos_cubed_sphere/tools/fv_diagnostics.F90
@@ -745,6 +745,8 @@ contains
           !            'Relative Humidity', '%', missing_value=missing_value, range=rhrange )
           idiag%id_delp = register_diag_field ( trim(field), 'delp', axes(1:3), Time,        &
                'pressure thickness', 'pa', missing_value=missing_value )
+          idiag%id_total_delp = register_diag_field ( trim(field), 'total_delp', axes(1:3), Time,        &
+               'total pressure thickness including hydrometeor mass', 'pa', missing_value=missing_value )
           if ( .not. Atm(n)%flagstruct%hydrostatic )                                        &
                idiag%id_delz = register_diag_field ( trim(field), 'delz', axes(1:3), Time,        &
                'height thickness', 'm', missing_value=missing_value )
@@ -2703,6 +2705,10 @@ contains
           endif
        endif
 
+
+       if (idiag%total_delp > 0) then
+         used = send_data(idiag%id_total_delp, Atm(n)%delp(isc:iec,jsc:jec,1:npz), Time)
+       endif
 
 #ifdef GFS_PHYS
        if(idiag%id_delp > 0 .or. idiag%id_cape > 0 .or. idiag%id_cin > 0 .or. ((.not. Atm(n)%flagstruct%hydrostatic) .and. idiag%id_pfnh > 0)) then


### PR DESCRIPTION
This PR addresses a few issues related to our ability to write out the total pressure thickness as a diagnostic:
- Add a "total_delp"` diagnostic which represents the air mass as well as the hydrometeor mass.  This is in contrast to the existing "delp" diagnostic, which is just the air mass.
- Rename the "delp_coarse" diagnostic to "total_delp_coarse" since it is a more accurate name.
- ~~Fix a bug that led to a segmentation fault in the case that we wanted to output the "total_delp_coarse" diagnostic when we were pressure-level coarse-graining (this bug was introduced in porting and refactoring the initial implementation of coarse diagnostics in SHiELD to FV3GFS in December of 2020, #87, but it seems we just have not used it since).~~ This was not correct.  There was not a bug in the coarse pressure thickness diagnostic.  Still looking into what the source of the segmentation fault is.

I'm open to other suggestions for the name.  Another option might be to rename the existing "delp" diagnostic to something that indicates that the hydrometeor mass is removed, and reserve the "delp" name for diagnostics that most accurately represent the value of the `Atm%delp` variable that is carried around in the dynamical core.

### Remaining tasks 

- [ ] Update regression tests to include these diagnostics.