### PR TITLE
Add `gaea-c5` platform for building on Gaea's C5 partition

### DIFF
--- a/FV3/conf/configure.fv3.gaea-c5
+++ b/FV3/conf/configure.fv3.gaea-c5
@@ -1,0 +1,168 @@
+############
+# commands #
+############
+
+# Note that FC, CC, and CXX are implicitly defined variables in makefiles. Therefore 
+# special handling is required to give them default values.
+# https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+# https://stackoverflow.com/questions/18007326/how-to-change-default-values-of-variables-like-cc-in-makefile
+# https://www.gnu.org/software/make/manual/html_node/Origin-Function.html#Origin-Function
+ifeq ($(origin FC),default)
+FC = ftn
+endif
+ifeq ($(origin CC),default)
+CC = cc
+endif
+ifeq ($(origin CXX),default)
+CXX = CC
+endif
+LD = ftn
+
+#########
+# flags #
+#########
+# default is 64-bit OpenMP non-hydrostatic build using AVX2
+DEBUG =
+REPRO = Y
+VERBOSE =
+OPENMP = Y
+AVX2 = Y
+HYDRO = N
+32BIT = N
+
+include $(ESMFMKFILE)
+ESMF_INC = $(ESMF_F90COMPILEPATHS)
+ESMF_LIB = $(ESMF_F90ESMFLINKPATHS) $(ESMF_F90ESMFLINKLIBS)
+
+NEMSIOINC = -I$(NCEPLIBS_DIR)/include
+NCEPLIBS = $(ESMF_LIB) -L$(NCEPLIBS_DIR)/lib -lnemsio_d -lbacio_4 -lsp_v2.0.2_d -lw3emc_d -lw3nco_d
+
+##############################################
+# Need to use at least GNU Make version 3.81 #
+##############################################
+need := 3.81
+ok := $(filter $(need),$(firstword $(sort $(MAKE_VERSION) $(need))))
+ifneq ($(need),$(ok))
+$(error Need at least make version $(need).  Load module gmake/3.81)
+endif
+
+NETCDF_ROOT = $(NETCDF_DIR)
+INCLUDE = -I$(NETCDF_ROOT)/include
+
+# The FPPFLAGS option -DHARMONIZE_PROCEDURE_POINTER_INTENTS is specified
+# to avoid unwanted errors when compiling the model. The source of the
+# errors is the mismatch between the way the "intent" of the arguments 
+# are defined in the interface definition of the proceduce pointer used
+# in the atmos_model.F90 and the way the "intent" of the arguments are
+# defined in the procedures the pointer points to.  This issue comes up
+# when using newer Intel compilers.
+FPPFLAGS := -fpp -Wp,-w -DHARMONIZE_PROCEDURE_POINTER_INTENTS $(INCLUDE) -fPIC
+CFLAGS := $(INCLUDE) -fPIC
+
+FFLAGS := $(INCLUDE) -fPIC -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -nowarn -sox -align array64byte
+
+CPPDEFS += -Duse_libMPI -Duse_netCDF -DSPMD -DUSE_LOG_DIAG_FIELD_INFO -DUSE_GFSL63 -DGFS_PHYS 
+CPPDEFS += -DNEW_TAUCTMAX -DINTERNAL_FILE_NML -DNO_INLINE_POST -Duse_LARGEFILE
+
+ifeq ($(GT4PY_DEV),Y)
+CPPDEFS += -DGT4PY_DEV
+endif
+
+ifeq ($(AI2_SUBSET_PHYSICS),Y)
+CPPDEFS += -DAI2_SUBSET_PHYSICS
+endif
+
+ifeq ($(HYDRO),Y)
+CPPDEFS += 
+else
+CPPDEFS += -DMOIST_CAPPA -DUSE_COND
+endif
+
+ifeq ($(32BIT),Y)
+CPPDEFS += -DOVERLOAD_R4 -DOVERLOAD_R8
+FFLAGS += -i4 -real-size 32
+else
+FFLAGS += -i4 -real-size 64 -no-prec-div -no-prec-sqrt
+endif
+
+# Note that on Gaea's C5 partition we use the -march=core-avx-i flag instead of
+# -xCORE-AVX2 or -march=core-avx2.
+ifeq ($(AVX2),Y)
+FFLAGS += -march=core-avx-i -qno-opt-dynamic-align
+CFLAGS += -march=core-avx-i -qno-opt-dynamic-align
+else
+FFLAGS += -xHOST -qno-opt-dynamic-align
+CFLAGS += -xHOST -qno-opt-dynamic-align
+endif
+
+FFLAGS_OPT = -O2 -debug minimal -fp-model source -qoverride-limits -qopt-prefetch=3
+FFLAGS_REPRO = -O2 -debug minimal -fp-model source -qoverride-limits -g -traceback
+FFLAGS_DEBUG = -g -O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fp-stack-check -fstack-protector-all -fpe0 -debug -traceback -ftrapuv
+
+TRANSCENDENTALS := -fast-transcendentals
+FFLAGS_OPENMP = -qopenmp
+FFLAGS_VERBOSE = -v -V -what
+
+CFLAGS += -D__IFC -sox -fp-model source
+
+CFLAGS_OPT = -O2 -debug minimal
+CFLAGS_REPRO = -O2 -debug minimal
+CFLAGS_OPENMP = -qopenmp
+CFLAGS_DEBUG = -O0 -g -ftrapuv -traceback
+
+# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
+# *_TEST will match the production if no new option(s) is(are) to be tested.
+FFLAGS_TEST = -O3 -debug minimal -fp-model source -qoverride-limits
+CFLAGS_TEST = -O2
+
+LDFLAGS :=
+LDFLAGS_OPENMP := -qopenmp
+LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
+
+# start with blank LIBS
+LIBS :=
+
+ifneq ($(REPRO),)
+CFLAGS += $(CFLAGS_REPRO)
+FFLAGS += $(FFLAGS_REPRO)
+FAST :=
+else ifneq ($(DEBUG),)
+CFLAGS += $(CFLAGS_DEBUG)
+FFLAGS += $(FFLAGS_DEBUG)
+FAST :=
+else ifneq ($(TEST),)
+CFLAGS += $(CFLAGS_TEST)
+FFLAGS += $(FFLAGS_TEST)
+FAST :=
+else
+CFLAGS += $(CFLAGS_OPT)
+FFLAGS += $(FFLAGS_OPT)
+FAST := $(TRANSCENDENTALS)
+endif
+
+ifneq ($(OPENMP),)
+CFLAGS += $(CFLAGS_OPENMP)
+FFLAGS += $(FFLAGS_OPENMP)
+LDFLAGS += $(LDFLAGS_OPENMP)
+# to correct a loader bug on gaea: envars below set by module load intel
+LIBS += -L$(INTEL_PATH)/$(INTEL_MAJOR_VERSION)/$(INTEL_MINOR_VERSION)/lib/intel64 -lifcoremt
+endif
+
+ifneq ($(VERBOSE),)
+CFLAGS += $(CFLAGS_VERBOSE)
+FFLAGS += $(FFLAGS_VERBOSE)
+LDFLAGS += $(LDFLAGS_VERBOSE)
+endif
+
+ifneq ($(CALLPYFORT),)
+FFLAGS += -I$(CALLPYFORT)/build/src -DENABLE_CALLPYFORT
+LDFLAGS += -L$(CALLPYFORT)/build/src -lcallpy 
+endif
+
+ifneq ($(findstring netcdf/4,$(LOADEDMODULES)),)
+  LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
+else
+  LIBS += -lnetcdf
+endif
+
+LDFLAGS += $(LIBS) $(FMS_DIR)/libFMS/.libs/libFMS.a

--- a/FV3/conf/modules.fv3.gaea-c5
+++ b/FV3/conf/modules.fv3.gaea-c5
@@ -1,0 +1,12 @@
+# NOTE: the "module purge" and loading of the module command are
+# handled by the module-setup.sh (or .csh) script.
+##
+## load programming environment
+## this typically includes compiler, MPI and job scheduler
+##
+module load PrgEnv-intel/8.3.3
+module load intel-classic/2022.0.2
+module load cray-mpich/8.1.16
+module load cray-hdf5/1.12.2.3
+module load cray-netcdf/4.9.0.3
+module load cmake/3.23.1


### PR DESCRIPTION
This PR adds configuration information for building the fortran model on Gaea's new C5 partition.  This is effectively a new system and requires different modules than the previous C3/C4 partitions (which the existing `gaea` configuration is targeted to).  ORNL will eventually recommend everyone move their work to the C5 partition and they are encouraging users to try running their jobs there now.

For reviewing purposes, this is a diff of the `configure.fv3.gaea` file with the new `configure.fv3.gaea-c5` file:
```diff
$ diff configure.fv3.gaea configure.fv3.gaea-c5
52c52,59
< FPPFLAGS := -fpp -Wp,-w $(INCLUDE) -fPIC
---
> # The FPPFLAGS option -DHARMONIZE_PROCEDURE_POINTER_INTENTS is specified
> # to avoid unwanted errors when compiling the model. The source of the
> # errors is the mismatch between the way the "intent" of the arguments
> # are defined in the interface definition of the proceduce pointer used
> # in the atmos_model.F90 and the way the "intent" of the arguments are
> # defined in the procedures the pointer points to.  This issue comes up
> # when using newer Intel compilers.
> FPPFLAGS := -fpp -Wp,-w -DHARMONIZE_PROCEDURE_POINTER_INTENTS $(INCLUDE) -fPIC
80a88,89
> # Note that on Gaea's C5 partition we use the -march=core-avx-i flag instead of
> # -xCORE-AVX2 or -march=core-avx2.
82,83c91,92
< FFLAGS += -xCORE-AVX2 -qno-opt-dynamic-align
< CFLAGS += -xCORE-AVX2 -qno-opt-dynamic-align
---
> FFLAGS += -march=core-avx-i -qno-opt-dynamic-align
> CFLAGS += -march=core-avx-i -qno-opt-dynamic-align
```