### PR TITLE
Add column integrated physics tendency diagnostics

### DIFF
--- a/FV3/atmos_cubed_sphere/model/fv_arrays.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_arrays.F90
@@ -124,6 +124,7 @@ module fv_arrays_mod
 
      integer, allocatable :: id_vertically_integrated_tracers(:)
      integer :: id_delp_total
+     integer :: id_column_physics_heating, id_column_physics_moistening
   end type fv_diag_type
 
   type fv_coarse_diag_type

--- a/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_dynamics.F90
@@ -132,7 +132,7 @@ module fv_dynamics_mod
    use fv_mp_mod,           only: start_group_halo_update, complete_group_halo_update
    use fv_timing_mod,       only: timing_on, timing_off
    use diag_manager_mod,    only: send_data
-   use fv_diagnostics_mod,  only: fv_time, prt_mxm, range_check, prt_minmax
+   use fv_diagnostics_mod,  only: fv_time, prt_mxm, range_check, prt_minmax, compute_column_integral
    use mpp_domains_mod,     only: DGRID_NE, CGRID_NE, mpp_update_domains, domain2D
    use mpp_mod,             only: mpp_pe
    use field_manager_mod,   only: MODEL_ATMOS
@@ -147,7 +147,6 @@ module fv_dynamics_mod
    use fv_arrays_mod,       only: fv_grid_type, fv_flags_type, fv_atmos_type, fv_nest_type, & 
                                   fv_diag_type, fv_grid_bounds_type, fv_sat_adj_tendency_diag_type
    use fv_nwp_nudge_mod,    only: do_adiabatic_init
-   use fv_update_phys_mod,  only: compute_column_integral
 #ifdef MULTI_GASES
    use multi_gases_mod,     only:  virq, virqd, vicpqd
 #endif

--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -104,7 +104,7 @@ module fv_update_phys_mod
   use boundary_mod,       only: extrapolation_BC
   use fv_eta_mod,         only: get_eta_level
   use fv_timing_mod,      only: timing_on, timing_off
-  use fv_diagnostics_mod, only: prt_maxmin
+  use fv_diagnostics_mod, only: prt_maxmin, compute_column_integral
   use fv_mapz_mod,        only: moist_cv, moist_cp
 #if defined (ATMOS_NUDGE)
   use atmos_nudge_mod,    only: get_atmos_nudge, do_ps
@@ -1219,13 +1219,5 @@ if (allocated(physics_tendency_diag%t_dt)) physics_tendency_diag%t_dt = (pt(is:i
     enddo     ! k-loop
 
   end subroutine update2d_dwinds_phys
-
-  subroutine compute_column_integral(integrand, delp, is, ie, js, je, npz, column_integral)
-    integer, intent(in) :: is, ie, js, je, npz
-    real, intent(in), dimension(is:ie,js:je,1:npz) :: integrand, delp
-    real, intent(out) :: column_integral(is:ie,js:je)
-
-    column_integral = sum(integrand * delp, 3) / grav
-  end subroutine compute_column_integral
 
 end module fv_update_phys_mod

--- a/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
+++ b/FV3/atmos_cubed_sphere/model/fv_update_phys.F90
@@ -123,7 +123,7 @@ module fv_update_phys_mod
 
   implicit none
 
-  public :: fv_update_phys, del2_phys, compute_column_integral
+  public :: fv_update_phys, del2_phys
 #ifdef ROT3
   public :: update_dwinds_phys
 #endif


### PR DESCRIPTION
This PR adds column-integrated physics tendency diagnostics for temperature and specific humidity.  In the case of temperature we follow what was done for the column integrated nudging and fv_sat_adj tendencies, where we scale the column integrated result by either Cp or Cv depending on whether the model is run hydrostatically or non-hydrostatically.  As in those cases we do not take into account moist effects when computing these values.  That's something we could eventually think about modifying, but might be better for a future PR.

Note: I moved the `compute_column_integral` subroutine to the `fv_diagnostics` module to work around a circular import.

[This notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2023-04-07-column-physics-diagnostics/2023-04-07-test-column-physics-diagnostics.ipynb) verifies that these diagnostics match what we would get if we computed them offline.
