### PR TITLE
Update modules for `gaea-c5` platform

### DIFF
--- a/FV3/conf/modules.fv3.gaea-c5
+++ b/FV3/conf/modules.fv3.gaea-c5
@@ -5,8 +5,8 @@
 ## this typically includes compiler, MPI and job scheduler
 ##
 module load PrgEnv-intel/8.3.3
-module load intel-classic/2022.0.2
-module load cray-mpich/8.1.16
+module load intel-classic/2022.2.1
+module load cray-mpich/8.1.25
 module load cray-hdf5/1.12.2.3
 module load cray-netcdf/4.9.0.3
 module load cmake/3.23.1


### PR DESCRIPTION
This PR updates the modules loaded for building FV3GFS on Gaea's C5 partition.  We update `intel-classic/2022.0.2` to `intel-classic/2022.2.1` to be consistent with its current default version on C5, and perhaps more importantly, update `cray-mpich/8.1.16` to `cray-mpich/8.1.25`, since `cray-mpich/8.1.16` was removed in a recent software update.