### PR TITLE
Add diagnostics-manager-controlled versions of `tsfc`, `u10m`, and `v10m`

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -3812,6 +3812,45 @@ module GFS_diagnostics
     ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
   enddo
 
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'tsfc_via_diagnostics_manager'
+  ExtDiag(idx)%desc = 'surface temperature'
+  ExtDiag(idx)%unit = 'K'
+  ExtDiag(idx)%mod_name = 'gfs_sfc'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .TRUE.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%tsfc(:)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'u10m_via_diagnostics_manager'
+  ExtDiag(idx)%desc = '10 meter u wind'
+  ExtDiag(idx)%unit = 'm/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .TRUE.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%u10m(:)
+  enddo
+
+  idx = idx + 1
+  ExtDiag(idx)%axes = 2
+  ExtDiag(idx)%name = 'v10m_via_diagnostics_manager'
+  ExtDiag(idx)%desc = '10 meter v wind'
+  ExtDiag(idx)%unit = 'm/s'
+  ExtDiag(idx)%mod_name = 'gfs_phys'
+  ExtDiag(idx)%coarse_graining_method = 'area_weighted'
+  ExtDiag(idx)%diag_manager_controlled = .TRUE.
+  allocate (ExtDiag(idx)%data(nblks))
+  do nb = 1,nblks
+    ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%v10m(:)
+  enddo
+
   call populate_emulator_diagnostics(&
     ExtDiag, IntDiag(:)%zhao_carr_emulator, 'zhao_carr_microphysics', 'emulator', nblks, idx)
   call populate_emulator_diagnostics(&


### PR DESCRIPTION
The existing `tsfc`, `u10m`, and `v10m` fields are hard-coded to be instantaneous diagnostics.  It is currently not possible to output interval average versions of these fields.  This PR addresses this issue by adding diagnostics-manager-controlled versions of these fields  Implementing them as diagnostics-manager-controlled allows for flexibility in saving them out as instantaneous fields or interval averages with flexible averaging windows, just like diagnostics in the dynamical core.  

The added fields are suffixed with `_via_diagnostics_manager`.  This name is a little verbose, but I'm hesitant to remove the existing non-diagnostics-manager versions of these fields for backwards compatibility.  Fortunately this suffix can be removed by specifying a custom output name in the diagnostics table.

I have validated that these fields work as expected in the notebook in [this directory](https://github.com/ai2cm/explore/tree/master/spencerc/2023-08-10-implement-new-diag-manager-controlled-diagnostics), both in terms of interval-averaging and coarsening.  I do not think it is necessary to add these fields to regression tests since we have coverage of other diagnostics-manager-controlled [native](https://github.com/ai2cm/fv3gfs-fortran/blob/198c77b2303497d4c245b35bbbfad4e3d2ab12d6/tests/pytest/config/emulation.yml#L17-L53) and [coarse-resolution fields](https://github.com/ai2cm/fv3gfs-fortran/blob/198c77b2303497d4c245b35bbbfad4e3d2ab12d6/tests/pytest/config/blended-area-weighted-coarse-graining.yml#L137-L191) in checksums already.