### PR TITLE
Make cloud cover and instantaneous downward shortwave diagnostics coarsenable

### DIFF
--- a/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/FV3/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -617,6 +617,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%fluxr(:,17)
@@ -685,6 +686,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%fluxr(:,5)
@@ -744,6 +746,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%fluxr(:,6)
@@ -803,6 +806,7 @@ module GFS_diagnostics
     ExtDiag(idx)%cnvfac = cn_100
     ExtDiag(idx)%time_avg = .TRUE.
     ExtDiag(idx)%time_avg_kind = 'rad_swlw_min'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%fluxr(:,7)
@@ -922,6 +926,7 @@ module GFS_diagnostics
     ExtDiag(idx)%unit = 'w/m**2'
     ExtDiag(idx)%mod_name = 'gfs_phys'
     ExtDiag(idx)%intpl_method = 'bilinear'
+    ExtDiag(idx)%coarse_graining_method = 'area_weighted'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
       ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%topfsw(:)%dnfxc


### PR DESCRIPTION
This PR adds `coarse_graining_method` attributes to the `TCDC_aveclm`, `TCDC_avehcl`, `TCDC_avemcl`, `TCDC_avelcl`, and `sw_dnfxc` physics diagnostics, making them possible to coarse grain online.  `sw_dnfxc` is the instantaneous downward shortwave radiative flux; it is not possible to use when compiling with `gfortran`, e.g. in our Docker images, but is possible to use with Intel compilers, e.g. on Gaea.

[This notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2023-08-11-implement-new-coarse-diagnostics/2023-08-11-validate-new-diagnostics.ipynb) does a sanity check on the coarse cloud cover fields, verifying that their offline coarsened values match their online coarsened values.