### PR TITLE
Fix bug in computing the blending pressure for the D-grid x-wind

### DIFF
--- a/FV3/coarse_graining/coarse_graining.F90
+++ b/FV3/coarse_graining/coarse_graining.F90
@@ -1238,7 +1238,7 @@ contains
    call interpolate_to_d_grid_and_downsample_along_y(phalf, phalf_d_grid, npz+1)
    call weighted_block_edge_average_x_pre_downsampled(phalf_d_grid, dx, coarse_phalf_d_grid, npz+1)
    call compute_coarse_pfull(coarse_phalf_d_grid, coarse_pfull_d_grid, x_pad=0, y_pad=1)
-   call block_edge_min_x(phalf_d_grid(is:ie,js_coarse:je_coarse,npz+1), blending_pressure)
+   call block_edge_min_x(phalf_d_grid(is:ie,js_coarse:je_coarse+1,npz+1), blending_pressure)
    coarse_surface_pressure = coarse_phalf_d_grid(is_coarse:ie_coarse,js_coarse:je_coarse+1,npz+1)
    blending_pressure = sigma_blend * blending_pressure
 


### PR DESCRIPTION
This is a typo that made it into #370.  Somehow when coarsening at C12 resolution by only a factor of two it did not make a difference in the result, but when validating blended-area-weighted coarse-graining in SHiELD, going from C48 resolution to C6, it emerged.  

Fortunately we have not used the blended coarse-grained D-grid winds for any experiments up to this point--we have switched to nudging to A-grid winds in nudged runs--so this has not affected any important results.

[This notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2023-08-18-validate-blended-area-weighted-coarsening-SHiELD-bug.ipynb) illustrates the symptom of the bug (large differences between online and offline coarsened values for the D-grid x-wind in the uppermost row of each tile); [this notebook](https://github.com/ai2cm/explore/blob/master/spencerc/2023-08-18-validate-blended-area-weighted-coarsening-SHiELD-fix.ipynb) illustrates that this fixes this bug.