### PR TITLE
Optimize pressure-level-extrapolate coarsening for physics diagnostics

### DIFF
--- a/FV3/io/FV3GFS_io.F90
+++ b/FV3/io/FV3GFS_io.F90
@@ -3018,7 +3018,8 @@ module FV3GFS_io_mod
         allocate(masked_area(nx, ny, levs))
         extrapolate = trim(coarsening_strategy) .eq. PRESSURE_LEVEL_EXTRAPOLATE
         call get_area(Atm_block, IPD_Data, nx, ny, area)
-        if (trim(coarsening_strategy) .eq. PRESSURE_LEVEL) then
+        if (trim(coarsening_strategy) .eq. PRESSURE_LEVEL .or. &
+            trim(coarsening_strategy) .eq. PRESSURE_LEVEL_EXTRAPOLATE) then
           call vertical_remapping_requirements(delp, area, ptop, phalf, phalf_coarse_on_fine)
         else
           call get_coarse_array_bounds(is_coarse, ie_coarse, js_coarse, je_coarse)
@@ -3168,7 +3169,8 @@ module FV3GFS_io_mod
           allocate(masked_area(nx, ny, levs))
           extrapolate = trim(coarsening_strategy) .eq. PRESSURE_LEVEL_EXTRAPOLATE
           call get_area(Atm_block, IPD_Data, nx, ny, area)
-          if (trim(coarsening_strategy) .eq. PRESSURE_LEVEL) then
+          if (trim(coarsening_strategy) .eq. PRESSURE_LEVEL .or. &
+              trim(coarsening_strategy) .eq. PRESSURE_LEVEL_EXTRAPOLATE) then
             call vertical_remapping_requirements(delp, area, ptop, phalf, phalf_coarse_on_fine)
           else
             call get_coarse_array_bounds(is_coarse, ie_coarse, js_coarse, je_coarse)


### PR DESCRIPTION
This small PR provides a small optimization to the pressure-level-extrapolate coarse-graining code pathway in the physics diagnostics following #370.  #370 introduced the need to compute blending weights when using blended-area-weighted coarse-graining.  We do not need to do this for the pressure-level and pressure-level-extrapolate modes, but accidentally left the blending weights to be computed in the pressure-level-extrapolate case within the physics diagnostics.  This PR fixes that.  It should not change answers, but should make things slightly more efficient.