### PR TITLE
Fix test skipping logic in debug-mode emulation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,19 @@ jobs:
       - run:
           name: Test wrapper
           command: nix-shell --run "make -C FV3/wrapper test_emulation"
+  nix-emulation-debug:
+    docker:
+      - image: nixos/nix
+    environment:
+      FV3CONFIG_CACHE_DIR: /tmp/.fv3config
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
+      FSSPEC_GS_REQUESTER_PAYS: vcm-ml
+    steps:
+      - initialize_nix
+      - build_debug
+      - run:
+          name: Test fortran
+          command: nix-shell --run "make test_fortran_emulation"
   nix-unmarked-repro:
     docker:
       - image: nixos/nix
@@ -232,16 +245,24 @@ workflows:
           filters:
             branches:
               ignore: master
-      - hold-nix-emulation-repro:
+      - hold-nix-emulation:
           name: Launch emulation tests
           type: approval
           filters:
             branches:
               ignore: master
       - nix-emulation-repro:
-          name: Emulation tests
+          name: Emulation tests in repro mode
           requires:
             - Minimal fortran and wrapper tests in repro mode
+            - Launch emulation tests
+          filters:
+            branches:
+              ignore: master
+      - nix-emulation-debug:
+          name: Emulation tests in debug mode
+          requires:
+            - Minimal fortran tests in debug mode
             - Launch emulation tests
           filters:
             branches:

--- a/tests/pytest/test_regression.py
+++ b/tests/pytest/test_regression.py
@@ -236,7 +236,7 @@ def test_use_prescribed_sea_surface_properties_error(executable, tmpdir, message
 @pytest.fixture(scope="session")
 def emulation_run(executable, tmpdir_factory):
     if "debug" in str(executable):
-        pytest.skip(reason=EMULATION_DEBUG_MODE_ISSUE)
+        pytest.skip(EMULATION_DEBUG_MODE_ISSUE)
 
     config = get_config("emulation.yml")
     rundir = tmpdir_factory.mktemp("rundir")
@@ -264,7 +264,7 @@ def test_zhao_carr_diagnostics(emulation_run, regtest, tile):
 @pytest.mark.emulation
 def test_gscond_logs(executable, regtest, tmpdir):
     if "debug" in str(executable):
-        pytest.skip(reason=EMULATION_DEBUG_MODE_ISSUE)
+        pytest.skip(EMULATION_DEBUG_MODE_ISSUE)
 
     config = get_config("emulation.yml")
     config["namelist"]["gfs_physics_nml"]["emulate_gscond_only"] = True


### PR DESCRIPTION
This PR fixes errors in test skipping logic introduced in #379 (see [this CI run](https://app.circleci.com/pipelines/github/ai2cm/fv3gfs-fortran/2682/workflows/e71d0119-0c60-44c7-bf4f-d97f10ccbb0b/jobs/5541)).  In that PR these particular tests were configured only to be attempted to be run upon merges to master, because they would be skipped anyway.  

This PR also now ensures that we at least attempt to run the emulation tests in debug mode in CI when the developer requests to, since it will exercise the skipping logic before merging to master (upon which all pure fortran tests are attempted to be run in both repro and debug mode).

[This CI job](https://app.circleci.com/pipelines/github/ai2cm/fv3gfs-fortran/2688/workflows/0c3ca3a2-3b4d-46d6-8cca-a65e1b9a5a0f/jobs/5557) confirms that this PR worked as intended.